### PR TITLE
feat: 新バージョンのdocsをこのレポジトリに引っ張ってくる

### DIFF
--- a/docs/advanced-features/amp-support/adding-amp-components.md
+++ b/docs/advanced-features/amp-support/adding-amp-components.md
@@ -1,0 +1,60 @@
+---
+description: Add components from the AMP community to AMP pages, and make your pages more interactive.
+---
+
+# Adding AMP Components
+
+The AMP community provides [many components](https://amp.dev/documentation/components/) to make AMP pages more interactive. Next.js will automatically import all components used on a page and there is no need to manually import AMP component scripts:
+
+```jsx
+export const config = { amp: true };
+
+function MyAmpPage() {
+  const date = new Date();
+
+  return (
+    <div>
+      <p>Some time: {date.toJSON()}</p>
+      <amp-timeago width="0" height="15" datetime={date.toJSON()} layout="responsive">
+        .
+      </amp-timeago>
+    </div>
+  );
+}
+
+export default MyAmpPage;
+```
+
+The above example uses the [`amp-timeago`](https://amp.dev/documentation/components/amp-timeago/?format=websites) component.
+
+By default, the latest version of a component is always imported. If you want to customize the version, you can use `next/head`, as in the following example:
+
+```jsx
+import Head from 'next/head';
+
+export const config = { amp: true };
+
+function MyAmpPage() {
+  const date = new Date();
+
+  return (
+    <div>
+      <Head>
+        <script
+          async
+          key="amp-timeago"
+          custom-element="amp-timeago"
+          src="https://cdn.ampproject.org/v0/amp-timeago-0.1.js"
+        />
+      </Head>
+
+      <p>Some time: {date.toJSON()}</p>
+      <amp-timeago width="0" height="15" datetime={date.toJSON()} layout="responsive">
+        .
+      </amp-timeago>
+    </div>
+  );
+}
+
+export default MyAmpPage;
+```

--- a/docs/advanced-features/amp-support/amp-in-static-html-export.md
+++ b/docs/advanced-features/amp-support/amp-in-static-html-export.md
@@ -1,0 +1,33 @@
+---
+description: Learn how AMP pages are created when used together with `next export`.
+---
+
+# AMP in Static HTML export
+
+When using `next export` to do [Static HTML export](/docs/advanced-features/static-html-export.md) statically prerender pages, Next.js will detect if the page supports AMP and change the exporting behavior based on that.
+
+For example, the hybrid AMP page `pages/about.js` would output:
+
+- `out/about.html` - HTML page with client-side React runtime
+- `out/about.amp.html` - AMP page
+
+And if `pages/about.js` is an AMP-only page, then it would output:
+
+- `out/about.html` - Optimized AMP page
+
+Next.js will automatically insert a link to the AMP version of your page in the HTML version, so you don't have to, like so:
+
+```jsx
+<link rel="amphtml" href="/about.amp.html" />
+```
+
+And the AMP version of your page will include a link to the HTML page:
+
+```jsx
+<link rel="canonical" href="/about" />
+```
+
+When [`exportTrailingSlash`](/docs/api-reference/next.config.js/exportPathMap.md#0cf7d6666b394c5d8d08a16a933e86ea) is enabled the exported pages for `pages/about.js` would be:
+
+- `out/about/index.html` - HTML page
+- `out/about.amp/index.html` - AMP page

--- a/docs/advanced-features/amp-support/amp-validation.md
+++ b/docs/advanced-features/amp-support/amp-validation.md
@@ -1,0 +1,9 @@
+---
+description: AMP pages are automatically validated by Next.js during development and on build. Learn more about it here.
+---
+
+# AMP Validation
+
+AMP pages are automatically validated with [amphtml-validator](https://www.npmjs.com/package/amphtml-validator) during development. Errors and warnings will appear in the terminal where you started Next.js.
+
+Pages are also validated during [Static HTML export](/docs/advanced-features/static-html-export.md) and any warnings / errors will be printed to the terminal. Any AMP errors will cause the export to exit with status code `1` because the export is not valid AMP.

--- a/docs/advanced-features/amp-support/introduction.md
+++ b/docs/advanced-features/amp-support/introduction.md
@@ -1,0 +1,42 @@
+---
+description: With minimal config, and without leaving React, you can start adding AMP and improve the performance and speed of your pages.
+---
+
+# AMP Support
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/amp">AMP</a></li>
+  </ul>
+</details>
+
+With Next.js you can turn any React page into an AMP page, with minimal config, and without leaving React.
+
+You can read more about AMP in the official [amp.dev](https://amp.dev/) site.
+
+## Enabling AMP
+
+To enable AMP support for a page, and to learn more about the different AMP configs, read the [API documentation for `next/amp`](/docs/api-reference/next/amp.md).
+
+## Caveats
+
+- Only CSS-in-JS is supported. [CSS Modules](/docs/basic-features/built-in-css-support.md) aren't supported by AMP pages at the moment. You can [contribute CSS Modules support to Next.js](https://github.com/zeit/next.js/issues/10549).
+
+## Related
+
+For more information on what to do next, we recommend the following sections:
+
+<div class="card">
+  <a href="/docs/advanced-features/amp-support/adding-amp-components.md">
+    <b>AMP Components:</b>
+    <small>Make your pages more interactive with AMP components.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/advanced-features/amp-support/amp-validation.md">
+    <b>AMP Validation:</b>
+    <small>Learn about how Next.js validates AMP pages.</small>
+  </a>
+</div>

--- a/docs/advanced-features/amp-support/typescript.md
+++ b/docs/advanced-features/amp-support/typescript.md
@@ -1,0 +1,9 @@
+---
+description: Using AMP with TypeScript? Extend your typings to allow AMP components.
+---
+
+# TypeScript
+
+AMP currently doesn't have built-in types for TypeScript, but it's in their roadmap ([#13791](https://github.com/ampproject/amphtml/issues/13791)).
+
+As a workaround you can manually create a file called `amp.d.ts` inside your project and add the custom types described [here](https://stackoverflow.com/a/50601125).

--- a/docs/advanced-features/automatic-static-optimization.md
+++ b/docs/advanced-features/automatic-static-optimization.md
@@ -1,0 +1,42 @@
+---
+description: Next.js automatically optimizes your app to be static HTML whenever possible. Learn how it works here.
+---
+
+# Automatic Static Optimization
+
+Next.js automatically determines that a page is static (can be prerendered) if it has no blocking data requirements. This determination is made by the absence of `getServerSideProps` and `getInitialProps` in the page.
+
+This feature allows Next.js to emit hybrid applications that contain **both server-rendered and statically generated pages**.
+
+> Statically generated pages are still reactive: Next.js will hydrate your application client-side to give it full interactivity.
+
+One of the main benefits of this feature is that optimized pages require no server-side computation, and can be instantly streamed to the end-user from multiple CDN locations. The result is an _ultra fast_ loading experience for your users.
+
+## How it works
+
+If `getServerSideProps` or `getInitialProps` is present in a page, Next.js will switch to render the page on-demand, per-request (meaning [Server-Side Rendering](/docs/basic-features/pages.md#server-side-rendering)).
+
+If the above is not the case, Next.js will **statically optimize** your page automatically by prerendering the page to static HTML.
+
+During prerendering, the router's `query` object will be empty since we do not have `query` information to provide during this phase. After hydration, Next.js will trigger an update to your application to provide the route parameters in the `query` object.
+
+> **Note:** Parameters added with [dynamic routes](/docs/routing/dynamic-routes.md) to a page that's using [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation) will always be available inside the `query` object.
+
+`next build` will emit `.html` files for statically optimized pages. For example, the result for the page `pages/about.js` would be:
+
+```bash
+.next/server/static/${BUILD_ID}/about.html
+```
+
+And if you add `getServerSideProps` to the page, it will then be JavaScript, like so:
+
+```bash
+.next/server/static/${BUILD_ID}/about.js
+```
+
+In development you'll know if `pages/about.js` is optimized or not thanks to the included [static optimization indicator](/docs/api-reference/next.config.js/static-optimization-indicator.md).
+
+## Caveats
+
+- If you have a [custom `App`](/docs/advanced-features/custom-app.md) with `getInitialProps` then this optimization will be turned off in pages without [Static Generation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation).
+- If you have a [custom `Document`](/docs/advanced-features/custom-document.md) with `getInitialProps` be sure you check if `ctx.req` is defined before assuming the page is server-side rendered. `ctx.req` will be `undefined` for pages that are prerendered.

--- a/docs/advanced-features/custom-app.md
+++ b/docs/advanced-features/custom-app.md
@@ -1,0 +1,68 @@
+---
+description: Control page initialization and add a layout that persists for all pages by overriding the default App component used by Next.js.
+---
+
+# Custom `App`
+
+Next.js uses the `App` component to initialize pages. You can override it and control the page initialization. Which allows you to do amazing things like:
+
+- Persisting layout between page changes
+- Keeping state when navigating pages
+- Custom error handling using `componentDidCatch`
+- Inject additional data into pages
+- [Add global CSS](/docs/basic-features/built-in-css-support#adding-a-global-stylesheet)
+
+To override the default `App`, create the file `./pages/_app.js` as shown below:
+
+```jsx
+// import App from 'next/app'
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+// Only uncomment this method if you have blocking data requirements for
+// every single page in your application. This disables the ability to
+// perform automatic static optimization, causing every page in your app to
+// be server-side rendered.
+//
+// MyApp.getInitialProps = async (appContext) => {
+//   // calls page's `getInitialProps` and fills `appProps.pageProps`
+//   const appProps = await App.getInitialProps(appContext);
+//
+//   return { ...appProps }
+// }
+
+export default MyApp;
+```
+
+The `Component` prop is the active `page`, so whenever you navigate between routes, `Component` will change to the new `page`. Therefore, any props you send to `Component` will be received by the `page`.
+
+`pageProps` is an object with the initial props that were preloaded for your page by one of our [data fetching methods](/docs/basic-features/data-fetching.md), otherwise it's an empty object.
+
+### Caveats
+
+- If your app is running and you just added a custom `App`, you'll need to restart the development server. Only required if `pages/_app.js` didn't exist before.
+- Adding a custom `getInitialProps` in your `App` will disable [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) in pages without [Static Generation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation).
+
+### TypeScript
+
+If you’re using TypeScript, take a look at [our TypeScript documentation](/docs/basic-features/typescript#custom-app).
+
+## Related
+
+For more information on what to do next, we recommend the following sections:
+
+<div class="card">
+  <a href="/docs/advanced-features/automatic-static-optimization.md">
+    <b>Automatic Static Optimization:</b>
+    <small>Next.js automatically optimizes your app to be static HTML whenever possible. Learn how it works here.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/advanced-features/custom-error-page.md">
+    <b>Custom Error Page:</b>
+    <small>Learn more about the built-in Error page.</small>
+  </a>
+</div>

--- a/docs/advanced-features/custom-document.md
+++ b/docs/advanced-features/custom-document.md
@@ -1,0 +1,87 @@
+---
+description: Extend the default document markup added by Next.js.
+---
+
+# Custom `Document`
+
+A custom `Document` is commonly used to augment your application's `<html>` and `<body>` tags. This is necessary because Next.js pages skip the definition of the surrounding document's markup.
+
+A custom `Document` can also include `getInitialProps` for expressing asynchronous server-rendering data requirements.
+
+To override the default `Document`, create the file `./pages/_document.js` and extend the `Document` class as shown below:
+
+```jsx
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;
+```
+
+`<Html>`, `<Head />`, `<Main />` and `<NextScript />` are required for the page to be properly rendered.
+
+Custom attributes are allowed as props, like `lang`:
+
+```jsx
+<Html lang="en">
+```
+
+The `ctx` object is equivalent to the one received in [`getInitialProps`](/docs/api-reference/data-fetching/getInitialProps.md#context-object), with one addition:
+
+- `renderPage`: `Function` - a callback that runs the actual React rendering logic (synchronously). It's useful to decorate this function in order to support server-rendering wrappers like Aphrodite's [`renderStatic`](https://github.com/Khan/aphrodite#server-side-rendering)
+
+## Caveats
+
+- `Document` is only rendered in the server, event handlers like `onClick` won't work
+- React components outside of `<Main />` will not be initialized by the browser. Do _not_ add application logic here. If you need shared components in all your pages (like a menu or a toolbar), take a look at the [`App`](/docs/advanced-features/custom-app.md) component instead
+- `Document`'s `getInitialProps` function is not called during client-side transitions, nor when a page is [statically optimized](/docs/advanced-features/automatic-static-optimization.md)
+- Make sure to check if `ctx.req` / `ctx.res` are defined in `getInitialProps`. Those variables will be `undefined` when a page is being statically exported by [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) or by [`next export`](/docs/advanced-features/static-html-export.md)
+- Common errors include adding a `<title>` in the `<Head />` tag or using `styled-jsx`. These should be avoided in `pages/_document.js` as they lead to unexpected behavior
+
+## Customizing `renderPage`
+
+> It should be noted that the only reason you should be customizing `renderPage` is for usage with **css-in-js** libraries that need to wrap the application to properly work with server-side rendering.
+
+It takes as argument an options object for further customization:
+
+```jsx
+import Document from 'next/document';
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const originalRenderPage = ctx.renderPage;
+
+    ctx.renderPage = () =>
+      originalRenderPage({
+        // useful for wrapping the whole react tree
+        enhanceApp: App => App,
+        // useful for wrapping in a per-page basis
+        enhanceComponent: Component => Component
+      });
+
+    // Run the parent `getInitialProps`, it now includes the custom `renderPage`
+    const initialProps = await Document.getInitialProps(ctx);
+
+    return initialProps;
+  }
+}
+
+export default MyDocument;
+```

--- a/docs/advanced-features/custom-error-page.md
+++ b/docs/advanced-features/custom-error-page.md
@@ -1,0 +1,75 @@
+---
+description: Override and extend the built-in Error page to handle custom errors.
+---
+
+## 404 Page
+
+A 404 page may be accessed very often. Server-rendering an error page for every visit increases the load of the Next.js server. This can result in increased costs and slow experiences.
+
+To avoid the above pitfalls, Next.js provides a static 404 page by default without having to add any additional files.
+
+### Customizing The 404 Page
+
+To create a custom 404 page you can create a `pages/404.js` file. This file is statically generated at build time.
+
+```jsx
+// pages/404.js
+export default function Custom404() {
+  return <h1>404 - Page Not Found</h1>;
+}
+```
+
+## 500 Page
+
+By default Next.js provides a 500 error page that matches the default 404 page’s style. This page is not statically optimized as it allows server-side errors to be reported. This is why 404 and 500 (other errors) are separated.
+
+### Customizing The Error Page
+
+500 errors are handled both client-side and server-side by the `Error` component. If you wish to override it, define the file `pages/_error.js` and add the following code:
+
+```jsx
+function Error({ statusCode }) {
+  return (
+    <p>
+      {statusCode ? `An error ${statusCode} occurred on server` : 'An error occurred on client'}
+    </p>
+  );
+}
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+
+export default Error;
+```
+
+> `pages/_error.js` is only used in production. In development you’ll get an error with the call stack to know where the error originated from.
+
+### Reusing the built-in error page
+
+If you want to render the built-in error page you can by importing the `Error` component:
+
+```jsx
+import Error from 'next/error';
+
+export async function getServerSideProps() {
+  const res = await fetch('https://api.github.com/repos/zeit/next.js');
+  const errorCode = res.ok ? false : res.statusCode;
+  const json = await res.json();
+
+  return {
+    props: { errorCode, stars: json.stargazers_count }
+  };
+}
+
+export default function Page({ errorCode, stars }) {
+  if (errorCode) {
+    return <Error statusCode={errorCode} />;
+  }
+
+  return <div>Next stars: {stars}</div>;
+}
+```
+
+The `Error` component also takes `title` as a property if you want to pass in a text message along with a `statusCode`.

--- a/docs/advanced-features/custom-server.md
+++ b/docs/advanced-features/custom-server.md
@@ -1,0 +1,99 @@
+---
+description: Start a Next.js app programmatically using a custom server.
+---
+
+# Custom Server
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/custom-server">Basic custom server</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/custom-server-express">Express integration</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/custom-server-hapi">Hapi integration</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/custom-server-koa">Koa integration</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/ssr-caching">SSR Caching</a></li>
+  </ul>
+</details>
+
+Typically you start your next server with `next start`. It's possible, however, to start a server 100% programmatically in order to use custom route patterns.
+
+> Before deciding to use a custom server please keep in mind that it should only be used when the integrated router of Next.js can't meet your app requirements. A custom server will remove important performance optimizations, like **serverless functions** and **[Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md).**
+
+Take a look at the following example of a custom server:
+
+```js
+// server.js
+const { createServer } = require('http');
+const { parse } = require('url');
+const next = require('next');
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+app.prepare().then(() => {
+  createServer((req, res) => {
+    // Be sure to pass `true` as the second argument to `url.parse`.
+    // This tells it to parse the query portion of the URL.
+    const parsedUrl = parse(req.url, true);
+    const { pathname, query } = parsedUrl;
+
+    if (pathname === '/a') {
+      app.render(req, res, '/a', query);
+    } else if (pathname === '/b') {
+      app.render(req, res, '/b', query);
+    } else {
+      handle(req, res, parsedUrl);
+    }
+  }).listen(3000, err => {
+    if (err) throw err;
+    console.log('> Ready on http://localhost:3000');
+  });
+});
+```
+
+> `server.js` doesn't go through babel or webpack. Make sure the syntax and sources this file requires are compatible with the current node version you are running.
+
+Then, to run the custom server you'll need to update the `scripts` in `package.json`, like so:
+
+```json
+"scripts": {
+  "dev": "node server.js",
+  "build": "next build",
+  "start": "NODE_ENV=production node server.js"
+}
+```
+
+---
+
+The custom server uses the following import to connect the server with the Next.js application:
+
+```js
+const next = require('next');
+const app = next({});
+```
+
+The above `next` import is a function that receives an object with the following options:
+
+- `dev`: `Boolean` - Whether or not to launch Next.js in dev mode. Defaults to `false`
+- `dir`: `String` - Location of the Next.js project. Defaults to `'.'`
+- `quiet`: `Boolean` - Hide error messages containing server information. Defaults to `false`
+- `conf`: `object` - The same object you would use in [next.config.js](/docs/api-reference/next.config.js/introduction.md). Defaults to `{}`
+
+The returned `app` can then be used to let Next.js handle requests as required.
+
+## Disabling file-system routing
+
+By default, `Next` will serve each file in the `pages` folder under a pathname matching the filename. If your project uses a custom server, this behavior may result in the same content being served from multiple paths, which can present problems with SEO and UX.
+
+To disable this behavior and prevent routing based on files in `pages`, open `next.config.js` and disable the `useFileSystemPublicRoutes` config:
+
+```js
+module.exports = {
+  useFileSystemPublicRoutes: false
+};
+```
+
+> Note that `useFileSystemPublicRoutes` disables filename routes from SSR; client-side routing may still access those paths. When using this option, you should guard against navigation to routes you do not want programmatically.
+
+> You may also wish to configure the client-side Router to disallow client-side redirects to filename routes; for that refer to [`Router.beforePopState`](/docs/api-reference/next/router.md#router.beforePopState).

--- a/docs/advanced-features/customizing-babel-config.md
+++ b/docs/advanced-features/customizing-babel-config.md
@@ -1,0 +1,60 @@
+---
+description: Extend the babel preset added by Next.js with your own configs.
+---
+
+# Customizing Babel Config
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-custom-babel-config">Customizing babel configuration</a></li>
+  </ul>
+</details>
+
+Next.js includes the `next/babel` preset to your app, it includes everything needed to compile React applications and server-side code. But if you want to extend the default Babel configs, it's also possible.
+
+To start, you only need to define a `.babelrc` file at the top of your app, if such file is found, we're going to consider it the _source of truth_, therefore it needs to define what Next.js needs as well, which is the `next/babel` preset.
+
+Here's an example `.babelrc` file:
+
+```json
+{
+  "presets": ["next/babel"],
+  "plugins": []
+}
+```
+
+The `next/babel` presets includes:
+
+- preset-env
+- preset-react
+- preset-typescript
+- plugin-proposal-class-properties
+- plugin-proposal-object-rest-spread
+- plugin-transform-runtime
+- styled-jsx
+
+To configure these presets/plugins, **do not** add them to `presets` or `plugins` in your custom `.babelrc`. Instead, configure them on the `next/babel` preset, like so:
+
+```json
+{
+  "presets": [
+    [
+      "next/babel",
+      {
+        "preset-env": {},
+        "transform-runtime": {},
+        "styled-jsx": {},
+        "class-properties": {}
+      }
+    ]
+  ],
+  "plugins": []
+}
+```
+
+To learn more about the available options for each config, visit their documentation site.
+
+> Next.js uses the **current** Node.js version for server-side compilations.
+
+> The `modules` option on `"preset-env"` should be kept to `false`, otherwise webpack code splitting is turned off.

--- a/docs/advanced-features/customizing-postcss-config.md
+++ b/docs/advanced-features/customizing-postcss-config.md
@@ -1,0 +1,136 @@
+---
+description: Extend the PostCSS config and plugins added by Next.js with your own.
+---
+
+# Customizing PostCSS Config
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-tailwindcss">Tailwind CSS Example</a></li>
+  </ul>
+</details>
+
+## Default Behavior
+
+Next.js compiles CSS for its [built-in CSS support](/docs/basic-features/built-in-css-support) using PostCSS.
+
+Out of the box, with no configuration, Next.js compiles CSS with the following transformations:
+
+1. [Autoprefixer](https://github.com/postcss/autoprefixer) automatically adds vendor prefixes to CSS rules (back to IE11).
+1. [Cross-browser Flexbox bugs](https://github.com/philipwalton/flexbugs) are corrected to behave like [the spec](https://www.w3.org/TR/css-flexbox-1/).
+1. New CSS features are automatically compiled for Internet Explorer 11 compatibility:
+   - [`all` Property](https://developer.mozilla.org/en-US/docs/Web/CSS/all)
+   - [Break Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/break-after)
+   - [`font-variant` Property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant)
+   - [Gap Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/gap)
+   - [Media Query Ranges](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Syntax_improvements_in_Level_4)
+
+By default, [Custom Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/var) (CSS variables) are **not compiled** for IE11 support.
+
+CSS variables are not compiled because it is [not possible to safely do so](https://github.com/MadLittleMods/postcss-css-variables#caveats).
+If you must use variables, consider using something like [Sass variables](https://sass-lang.com/documentation/variables) which are compiled away by [Sass](https://sass-lang.com/).
+
+> **Note**: To support [Grid Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/grid), you need to enable `grid: "autoplace"` for Autoprefixer. See ["Customizing Plugins"](#customizing-plugins) below.
+
+## Customizing Target Browsers
+
+Next.js allows you to configure the target browsers (for [Autoprefixer](https://github.com/postcss/autoprefixer) and compiled css features) through [Browserslist](https://github.com/browserslist/browserslist).
+
+To customize browserslist, create a `browserslist` key in your `package.json` like so:
+
+```json
+{
+  "browserslist": [">0.3%", "not ie 11", "not dead", "not op_mini all"]
+}
+```
+
+You can use the [browserl.ist](https://browserl.ist/?q=%3E0.3%25%2C+not+ie+11%2C+not+dead%2C+not+op_mini+all) tool to visualize what browsers you are targeting.
+
+## CSS Modules
+
+No configuration is needed to support CSS Modules. To enable CSS Modules for a file, rename the file to have the extension `.module.css`.
+
+You can learn more about [Next.js' CSS Module support here](/docs/basic-features/built-in-css-support).
+
+## Customizing Plugins
+
+> **Warning**: When you define a custom PostCSS configuration file, Next.js **completely disables** the [default behavior](#default-behavior).
+> Be sure to manually configure all the features you need compiled, including [Autoprefixer](https://github.com/postcss/autoprefixer).
+> You also need to install any plugins included in your custom configuration manually, i.e. `npm install postcss-flexbugs-fixes`.
+
+To customize the PostCSS configuration, create a `postcss.config.json` file in the root of your project.
+
+This is the default configuration used by Next.js:
+
+```json
+{
+  "plugins": [
+    "postcss-flexbugs-fixes",
+    [
+      "postcss-preset-env",
+      {
+        "autoprefixer": {
+          "flexbox": "no-2009"
+        },
+        "stage": 3,
+        "features": {
+          "custom-properties": false
+        }
+      }
+    ]
+  ]
+}
+```
+
+> **Note**: Next.js also allows the file to be named `.postcssrc.json`, or, to be read from the `postcss` key in `package.json`.
+
+It is also possible to configure PostCSS with a `postcss.config.js` file, which is useful when you want to conditionally include plugins based on environment:
+
+```js
+module.exports = {
+  plugins:
+    process.env.NODE_ENV === 'production'
+      ? [
+          'postcss-flexbugs-fixes',
+          [
+            'postcss-preset-env',
+            {
+              autoprefixer: {
+                flexbox: 'no-2009'
+              },
+              stage: 3,
+              features: {
+                'custom-properties': false
+              }
+            }
+          ]
+        ]
+      : [
+          // No transformations in development
+        ]
+};
+```
+
+> **Note**: Next.js also allows the file to be named `.postcssrc.js`.
+
+Do **not use `require()`** to import the PostCSS Plugins. Plugins must be provided as strings.
+
+> **Note**: If your `postcss.config.js` needs to support other non-Next.js tools in the same project, you must use the interoperable object-based format instead:
+>
+> ```js
+> module.exports = {
+>   plugins: {
+>     'postcss-flexbugs-fixes': {},
+>     'postcss-preset-env': {
+>       autoprefixer: {
+>         flexbox: 'no-2009'
+>       },
+>       stage: 3,
+>       features: {
+>         'custom-properties': false
+>       }
+>     }
+>   }
+> };
+> ```

--- a/docs/advanced-features/dynamic-import.md
+++ b/docs/advanced-features/dynamic-import.md
@@ -1,0 +1,118 @@
+---
+description: Dynamically import JavaScript modules and React Components and split your code into manageable chunks.
+---
+
+# Dynamic Import
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-dynamic-import">Dynamic Import</a></li>
+  </ul>
+</details>
+
+Next.js supports ES2020 [dynamic `import()`](https://github.com/tc39/proposal-dynamic-import) for JavaScript. With it you can import JavaScript modules (inc. React Components) dynamically and work with them. They also work with SSR.
+
+You can think of dynamic imports as another way to split your code into manageable chunks.
+
+## Basic usage
+
+In the following example, the module `../components/hello` will be dynamically loaded by the page:
+
+```jsx
+import dynamic from 'next/dynamic';
+
+const DynamicComponent = dynamic(() => import('../components/hello'));
+
+function Home() {
+  return (
+    <div>
+      <Header />
+      <DynamicComponent />
+      <p>HOME PAGE is here!</p>
+    </div>
+  );
+}
+
+export default Home;
+```
+
+`DynamicComponent` will be the default component returned by `../components/hello`. It works like a regular React Component, and you can pass props to it as you normally would.
+
+## With named exports
+
+If the dynamic component is not the default export, you can use a named export too. Consider the module `../components/hello.js` which has a named export `Hello`:
+
+```jsx
+export function Hello() {
+  return <p>Hello!</p>;
+}
+```
+
+To dynamically import the `Hello` component, you can return it from the [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) returned by [`import()`](https://github.com/tc39/proposal-dynamic-import#example), like so:
+
+```jsx
+import dynamic from 'next/dynamic';
+
+const DynamicComponent = dynamic(() => import('../components/hello').then(mod => mod.Hello));
+
+function Home() {
+  return (
+    <div>
+      <Header />
+      <DynamicComponent />
+      <p>HOME PAGE is here!</p>
+    </div>
+  );
+}
+
+export default Home;
+```
+
+## With custom loading component
+
+An optional `loading` component can be added to render a loading state while the dynamic component is being loaded. For example:
+
+```jsx
+import dynamic from 'next/dynamic';
+
+const DynamicComponentWithCustomLoading = dynamic(() => import('../components/hello'), {
+  loading: () => <p>...</p>
+});
+
+function Home() {
+  return (
+    <div>
+      <Header />
+      <DynamicComponentWithCustomLoading />
+      <p>HOME PAGE is here!</p>
+    </div>
+  );
+}
+
+export default Home;
+```
+
+## With no SSR
+
+You may not always want to include a module on server-side. For example, when the module includes a library that only works in the browser.
+
+Take a look at the following example:
+
+```jsx
+import dynamic from 'next/dynamic';
+
+const DynamicComponentWithNoSSR = dynamic(() => import('../components/hello3'), { ssr: false });
+
+function Home() {
+  return (
+    <div>
+      <Header />
+      <DynamicComponentWithNoSSR />
+      <p>HOME PAGE is here!</p>
+    </div>
+  );
+}
+
+export default Home;
+```

--- a/docs/advanced-features/measuring-performance.md
+++ b/docs/advanced-features/measuring-performance.md
@@ -1,0 +1,171 @@
+---
+description: Measure and track page performance using Next.js's build-in performance relayer
+---
+
+# Measuring performance
+
+Next.js has a built-in relayer that allows you to analyze and measure the performance of
+pages using different metrics.
+
+To measure any of the supported metrics, you will need to create a [custom
+App](/docs/advanced-features/custom-app.md) component and define a `reportWebVitals` function:
+
+```js
+// pages/_app.js
+export function reportWebVitals(metric) {
+  console.log(metric);
+}
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;
+```
+
+This function is fired when the final values for any of the metrics have finished calculating on
+the page. You can use to log any of the results to the console or send to a particular endpoint.
+
+The `metric` object returned to the function consists of a number of properties:
+
+- `id`: Unique identifier for the metric in the context of the current page load
+- `name`: Metric name
+- `startTime`: First recorded timestamp of the performance entry (if applicable)
+- `value`: Value, or duration, of performance entry
+- `label`: Type of metric (`web-vital` or `custom`)
+
+There are two types of metrics that are tracked:
+
+- Web Vitals
+- Custom metrics
+
+## Web Vitals
+
+[Web Vitals](https://web.dev/vitals/) are a set of useful metrics that aim to capture the user
+experience of a web page. The following web vitals are all included:
+
+- [Time to First Byte](https://developer.mozilla.org/en-US/docs/Glossary/Time_to_first_byte) (TTFB)
+- [First Contentful Paint](https://developer.mozilla.org/en-US/docs/Glossary/First_contentful_paint) (FCP)
+- [Largest Contentful Paint](https://web.dev/lcp/) (LCP)
+- [First Input Delay](https://web.dev/fid/) (FID)
+- [Cumulative Layout Shift](https://web.dev/cls/) (CLS)
+
+You can handle all the results of these metrics using the `web-vital` label:
+
+```js
+export function reportWebVitals(metric) {
+  if (metric.label === 'web-vital') {
+    console.log(metric); // The metric object ({ id, name, startTime, value, label }) is logged to the console
+  }
+}
+```
+
+There's also the option of handling each of the metrics separately:
+
+```js
+export function reportWebVitals(metric) {
+  switch (metric.name) {
+    case 'FCP':
+      // handle FCP results
+      break;
+    case 'LCP':
+      // handle LCP results
+      break;
+    case 'CLS':
+      // handle CLS results
+      break;
+    case 'FID':
+      // handle FID results
+      break;
+    case 'TTFB':
+      // handle TTFB results
+      break;
+    default:
+      break;
+  }
+}
+```
+
+A third-party library, [web-vitals](https://github.com/GoogleChrome/web-vitals), is used to measure
+these metrics. Browser compatibility depends on the particular metric, so refer to the [Browser
+Support](https://github.com/GoogleChrome/web-vitals#browser-support) section to find out which
+browsers are supported.
+
+## Custom metrics
+
+In addition to the core metrics listed above, there are some additional custom metrics that
+measure the time it takes for the page to hydrate and render:
+
+- `Next.js-hydration`: Length of time it takes for the page to start and finish hydrating (in ms)
+- `Next.js-route-change-to-render`: Length of time it takes for a page to start rendering after a
+  route change (in ms)
+- `Next.js-render`: Length of time it takes for a page to finish render after a route change (in ms)
+
+You can handle all the results of these metrics using the `custom` label:
+
+```js
+export function reportWebVitals(metric) {
+  if (metric.label === 'custom') {
+    console.log(metric); // The metric object ({ id, name, startTime, value, label }) is logged to the console
+  }
+}
+```
+
+There's also the option of handling each of the metrics separately:
+
+```js
+export function reportWebVitals(metric) {
+  switch (metric.name) {
+    case 'Next.js-hydration':
+      // handle hydration results
+      break;
+    case 'Next.js-route-change-to-render':
+      // handle route-change to render results
+      break;
+    case 'Next.js-render':
+      // handle render results
+      break;
+    default:
+      break;
+  }
+}
+```
+
+These metrics work in all browsers that support the [User Timing API](https://caniuse.com/#feat=user-timing).
+
+## Sending results to analytics
+
+With the relay function, you can send any of results to an analytics endpoint to measure and track
+real user performance on your site. For example:
+
+```js
+export function reportWebVitals(metric) {
+  const body = JSON.stringify(metric);
+  const url = 'https://example.com/analytics';
+
+  // Use `navigator.sendBeacon()` if available, falling back to `fetch()`.
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(url, body);
+  } else {
+    fetch(url, { body, method: 'POST', keepalive: true });
+  }
+}
+```
+
+> **Note**: If you use [Google Analytics](https://analytics.google.com/analytics/web/), using the
+> `id` value can allow you to construct metric distributions manually (to calculate percentiles,
+> etc...).
+>
+> ```js
+> export function reportWebVitals({ id, name, label, value }) {
+>   ga('send', 'event', {
+>     eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
+>     eventAction: name,
+>     eventValue: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
+>     eventLabel: id, // id unique to current page load
+>     nonInteraction: true // avoids affecting bounce rate.
+>   });
+> }
+> ```
+>
+> Read more about sending results to Google Analytics [here](https://github.com/GoogleChrome/web-vitals#send-the-results-to-google-analytics).

--- a/docs/advanced-features/module-path-aliases.md
+++ b/docs/advanced-features/module-path-aliases.md
@@ -1,0 +1,86 @@
+---
+description: Configure module path aliases that allow you to remap certain import paths.
+---
+
+# Absolute Imports and Module path aliases
+
+Next.js automatically supports the `tsconfig.json` and `jsconfig.json` `"paths"` and `"baseUrl"` options.
+
+> Note: `jsconfig.json` can be used when you don't use TypeScript
+
+These option allow you to configure module aliases, for example a common pattern is aliasing certain directories to use absolute paths.
+
+One useful feature of these options is that they integrate automatically into certain editors, for example vscode.
+
+The `baseUrl` configuration option allows you to import directly from the root of the project.
+
+An example of this configuration:
+
+```json
+// tsconfig.json or jsconfig.json
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}
+```
+
+```jsx
+// components/button.js
+export default function Button() {
+  return <button>Click me</button>;
+}
+```
+
+```jsx
+// pages/index.js
+import Button from 'components/button';
+
+export default function HomePage() {
+  return (
+    <>
+      <h1>Hello World</h1>
+      <Button />
+    </>
+  );
+}
+```
+
+While `baseUrl` is useful you might want to add other aliases that don't match 1 on 1. For this TypeScript has the `"paths"` option.
+
+Using `"paths"` allows you to configure module aliases. For example `@/components/*` to `components/*`.
+
+An example of this configuration:
+
+```json
+// tsconfig.json or jsconfig.json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["components/*"]
+    }
+  }
+}
+```
+
+```jsx
+// components/button.js
+export default function Button() {
+  return <button>Click me</button>;
+}
+```
+
+```jsx
+// pages/index.js
+import Button from '@/components/button';
+
+export default function HomePage() {
+  return (
+    <>
+      <h1>Hello World</h1>
+      <Button />
+    </>
+  );
+}
+```

--- a/docs/advanced-features/multi-zones.md
+++ b/docs/advanced-features/multi-zones.md
@@ -1,0 +1,47 @@
+# Multi Zones
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="/examples/with-zones">With Zones</a></li>
+  </ul>
+</details>
+
+A zone is a single deployment of a Next.js app. You can have multiple zones and merge them as a single app.
+
+For example, let's say you have the following apps:
+
+- An app for serving `/blog/**`
+- Another app for serving all other pages
+
+With multi zones support, you can merge both these apps into a single one allowing your customers to browse it using a single URL, but you can develop and deploy both apps independently.
+
+## How to define a zone
+
+There are no special zones related APIs. You only need to do following:
+
+- Make sure to keep only the pages you need in your app, meaning that an app can't have pages from another app, if app `A` has `/blog` then app `B` shouldn't have it too.
+- Make sure to add an [assetPrefix](/docs/api-reference/next.config.js/cdn-support-with-asset-prefix.md) to avoid conflicts with static files.
+
+## How to merge zones
+
+You can merge zones using any HTTP proxy.
+
+For [Vercel](https://vercel.com/now), you can use a single `now.json` to deploy both apps. It allows you to define routing routes for multiple apps like below:
+
+```json
+{
+  "version": 2,
+  "builds": [
+    { "src": "blog/package.json", "use": "@now/next" },
+    { "src": "home/package.json", "use": "@now/next" }
+  ],
+  "routes": [
+    { "src": "/blog/_next(.*)", "dest": "blog/_next$1" },
+    { "src": "/blog(.*)", "dest": "blog/blog$1" },
+    { "src": "(.*)", "dest": "home$1" }
+  ]
+}
+```
+
+You can also configure a proxy server to route using a set of routes like the ones above, e.g deploy the blog app to `https://blog.example.com` and the home app to `https://home.example.com` and then add a proxy server for both apps in `https://example.com`.

--- a/docs/advanced-features/preview-mode.md
+++ b/docs/advanced-features/preview-mode.md
@@ -1,0 +1,227 @@
+---
+description: Next.js has the preview mode for statically generated pages. You can learn how it works here.
+---
+
+# Preview Mode
+
+> This document is for Next.js versions 9.3 and up. If you’re using older versions of Next.js, refer to our [previous documentation](https://nextjs.org/docs/tag/v9.2.2/basic-features/pages).
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-datocms">DatoCMS Example</a> (<a href="https://next-blog-datocms.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-takeshape">TakeShape Example</a> (<a href="https://next-blog-takeshape.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-sanity">Sanity Example</a> (<a href="https://next-blog-sanity.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-prismic">Prismic Example</a> (<a href="https://next-blog-prismic.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-contentful">Contentful Example</a> (<a href="https://next-blog-contentful.now.sh/">Demo</a>)</li>
+  </ul>
+</details>
+
+In the [Pages documentation](/docs/basic-features/pages.md) and the [Data Fetching documentation](/docs/basic-features/data-fetching.md), we talked about how to pre-render a page at build time (**Static Generation**) using `getStaticProps` and `getStaticPaths`.
+
+Static Generation is useful when your pages fetch data from a headless CMS. However, it’s not ideal when you’re writing a draft on your headless CMS and want to **preview** the draft immediately on your page. You’d want Next.js to render these pages at **request time** instead of build time and fetch the draft content instead of the published content. You’d want Next.js to bypass Static Generation only for this specific case.
+
+Next.js has the feature called **Preview Mode** which solves this problem. Here’s an instruction on how to use it.
+
+## Step 1. Create and access a preview API route
+
+> Take a look at the [API Routes documentation](/docs/api-routes/introduction.md) first if you’re not familiar with Next.js API Routes.
+
+First, create a **preview API route**. It can have any name - e.g. `pages/api/preview.js` (or `.ts` if using TypeScript).
+
+In this API route, you need to call `setPreviewData` on the response object. The argument for `setPreviewData` should be an object, and this can be used by `getStaticProps` (more on this later). For now, we’ll use `{}`.
+
+```js
+export default (req, res) => {
+  // ...
+  res.setPreviewData({});
+  // ...
+};
+```
+
+`res.setPreviewData` sets some **cookies** on the browser which turns on the preview mode. Any requests to Next.js containing these cookies will be considered as the **preview mode**, and the behavior for statically generated pages will change (more on this later).
+
+You can test this manually by creating an API route like below and accessing it from your browser manually:
+
+```js
+// A simple example for testing it manually from your browser.
+// If this is located at pages/api/preview.js, then
+// open /api/preview from your browser.
+export default (req, res) => {
+  res.setPreviewData({});
+  res.end('Preview mode enabled');
+};
+```
+
+If you use your browser’s developer tools, you’ll notice that the `__prerender_bypass` and `__next_preview_data` cookies will be set on this request.
+
+### Securely accessing it from your Headless CMS
+
+In practice, you’d want to call this API route _securely_ from your headless CMS. The specific steps will vary depending on which headless CMS you’re using, but here are some common steps you could take.
+
+These steps assume that the headless CMS you’re using supports setting **custom preview URLs**. If it doesn’t, you can still use this method to secure your preview URLs, but you’ll need to construct and access the preview URL manually.
+
+**First**, you should create a **secret token string** using a token generator of your choice. This secret will only be known by your Next.js app and your headless CMS. This secret prevents people who don’t have access to your CMS from accessing preview URLs.
+
+**Second**, if your headless CMS supports setting custom preview URLs, specify the following as the preview URL. (This assumes that your preview API route is located at `pages/api/preview.js`.)
+
+```bash
+https://<your-site>/api/preview?secret=<token>&slug=<path>
+```
+
+- `<your-site>` should be your deployment domain.
+- `<token>` should be replaced with the secret token you generated.
+- `<path>` should be the path for the page that you want to preview. If you want to preview `/posts/foo`, then you should use `&slug=/posts/foo`.
+
+Your headless CMS might allow you to include a variable in the preview URL so that `<path>` can be set dynamically based on the CMS’s data like so: `&slug=/posts/{entry.fields.slug}`
+
+**Finally**, in the preview API route:
+
+- Check that the secret matches and that the `slug` parameter exists (if not, the request should fail).
+-
+- Call `res.setPreviewData`.
+- Then redirect the browser to the path specified by `slug`. (The following example uses a [307 redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307)).
+
+```js
+export default async (req, res) => {
+  // Check the secret and next parameters
+  // This secret should only be known to this API route and the CMS
+  if (req.query.secret !== 'MY_SECRET_TOKEN' || !req.query.slug) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  // Fetch the headless CMS to check if the provided `slug` exists
+  // getPostBySlug would implement the required fetching logic to the headless CMS
+  const post = await getPostBySlug(req.query.slug);
+
+  // If the slug doesn't exist prevent preview mode from being enabled
+  if (!post) {
+    return res.status(401).json({ message: 'Invalid slug' });
+  }
+
+  // Enable Preview Mode by setting the cookies
+  res.setPreviewData({});
+
+  // Redirect to the path from the fetched post
+  // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities
+  res.writeHead(307, { Location: post.slug });
+  res.end();
+};
+```
+
+If it succeeds, then the browser will be redirected to the path you want to preview with the preview mode cookies being set.
+
+## Step 2. Update `getStaticProps`
+
+The next step is to update `getStaticProps` to support the preview mode.
+
+If you request a page which has `getStaticProps` with the preview mode cookies set (via `res.setPreviewData`), then `getStaticProps` will be called at **request time** (instead of at build time).
+
+Furthermore, it will be called with a `context` object where:
+
+- `context.preview` will be `true`.
+- `context.previewData` will be the same as the argument used for `setPreviewData`.
+
+```js
+export async function getStaticProps(context) {
+  // If you request this page with the preview mode cookies set:
+  //
+  // - context.preview will be true
+  // - context.previewData will be the same as
+  //   the argument used for `setPreviewData`.
+}
+```
+
+We used `res.setPreviewData({})` in the preview API route, so `context.previewData` will be `{}`. You can use this to pass session information from the preview API route to `getStaticProps` if necessary.
+
+If you’re also using `getStaticPaths`, then `context.params` will also be available.
+
+### Fetch preview data
+
+You can update `getStaticProps` to fetch different data based on `context.preview` and/or `context.previewData`.
+
+For example, your headless CMS might have a different API endpoint for draft posts. If so, you can use `context.preview` to modify the API endpoint URL like below:
+
+```js
+export async function getStaticProps(context) {
+  // If context.preview is true, append "/preview" to the API endpoint
+  // to request draft data instead of published data. This will vary
+  // based on which headless CMS you're using.
+  const res = await fetch(`https://.../${context.preview ? 'preview' : ''}`);
+  // ...
+}
+```
+
+That’s it! If you access the preview API route (with `secret` and `slug`) from your headless CMS or manually, you should now be able to see the preview content. And if you update your draft without publishing, you should be able to preview the draft.
+
+```bash
+# Set this as the preview URL on your headless CMS or access manually,
+# and you should be able to see the preview.
+https://<your-site>/api/preview?secret=<token>&slug=<path>
+```
+
+## More Details
+
+### Clear the preview mode cookies
+
+By default, no expiration date is set for the preview mode cookies, so the preview mode ends when the browser is closed.
+
+To clear the preview cookies manually, you can create an API route which calls `clearPreviewData` and then access this API route.
+
+```js
+export default (req, res) => {
+  // Clears the preview mode cookies.
+  // This function accepts no arguments.
+  res.clearPreviewData();
+  // ...
+};
+```
+
+### Specify the preview mode duration
+
+`setPreviewData` takes an optional second parameter which should be an options object. It accepts the following keys:
+
+- `maxAge`: Specifies the number (in seconds) for the preview session to last for.
+
+```js
+setPreviewData(data, {
+  maxAge: 60 * 60 // The preview mode cookies expire in 1 hour
+});
+```
+
+### `previewData` size limits
+
+You can pass an object to `setPreviewData` and have it be available in `getStaticProps`. However, because the data will be stored in a cookie, there’s a size limitation. Currently, preview data is limited to 2KB.
+
+### Works with `getServerSideProps`
+
+The preview mode works on `getServerSideProps` as well. It will also be available on the `context` object containing `preview` and `previewData`.
+
+### Unique per `next build`
+
+The bypass cookie value and private key for encrypting the `previewData` changes when a `next build` is ran, this ensures that the bypass cookie can’t be guessed.
+
+## Learn more
+
+The following pages might also be useful.
+
+<div class="card">
+  <a href="/docs/basic-features/data-fetching.md">
+    <b>Data Fetching:</b>
+    <small>Learn more about data fetching in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/api-routes/introduction.md">
+    <b>API Routes:</b>
+    <small>Learn more about API routes in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/environment-variables.md">
+    <b>Environment Variables:</b>
+    <small>Learn more about environment variables in Next.js.</small>
+  </a>
+</div>

--- a/docs/advanced-features/src-directory.md
+++ b/docs/advanced-features/src-directory.md
@@ -1,0 +1,25 @@
+---
+description: Save pages under the `src` directory as an alternative to the root `pages` directory.
+---
+
+# `src` Directory
+
+Pages can also be added under `src/pages` as an alternative to the root `pages` directory.
+
+The `src` directory is very common in many apps and Next.js supports it by default.
+
+## Caveats
+
+- `src/pages` will be ignored if `pages` is present in the root directory
+- Config files like `next.config.js` and `tsconfig.json` should be inside the root directory, moving them to `src` won't work. Same goes for the [`public` directory](/docs/basic-features/static-file-serving.md)
+
+## Related
+
+For more information on what to do next, we recommend the following sections:
+
+<div class="card">
+  <a href="/docs/basic-features/pages.md">
+    <b>Pages:</b>
+    <small>Learn more about what pages are in Next.js</small>
+  </a>
+</div>

--- a/docs/advanced-features/static-html-export.md
+++ b/docs/advanced-features/static-html-export.md
@@ -1,0 +1,58 @@
+---
+description: Export your Next.js app to static HTML, and run it standalone without the need of a Node.js server.
+---
+
+# Static HTML Export
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-static-export">Static Export</a></li>
+  </ul>
+</details>
+
+`next export` allows you to export your app to static HTML, which can be run standalone without the need of a Node.js server.
+
+The exported app supports almost every feature of Next.js, including dynamic routes, prefetching, preloading and dynamic imports.
+
+The way `next export` works is by prerendering all pages to HTML; it does so based on a mapping called [`exportPathMap`](/docs/api-reference/next.config.js/exportPathMap.md) which offers a way to pre-define paths you will render as html.
+
+> If your pages don't have `getInitialProps` you may not need `next export` at all; `next build` is already enough thanks to [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md).
+
+## How to use it
+
+Develop your app as you normally do with Next.js. Then run:
+
+```bash
+next build && next export
+```
+
+For that you may want to update the scripts in your `package.json` like this:
+
+```json
+"scripts": {
+  "build": "next build && next export"
+}
+```
+
+And run it at once with:
+
+```bash
+npm run build
+```
+
+Then you'll have a static version of your app in the `out` directory.
+
+By default `next export` doesn't require any configuration. It will generate a default `exportPathMap` with routes for the pages inside the `pages` directory.
+
+> To learn more about `exportPathMap` please visit the [documentation for the `exportPathMap` API](/docs/api-reference/next.config.js/exportPathMap.md).
+
+## Deployment
+
+You can read about deploying your Next.js application in the [deployment section](/docs/deployment.md).
+
+## Caveats
+
+- With `next export`, we build an HTML version of your app. At export time we will run the [`getInitialProps`](/docs/api-reference/data-fetching/getInitialProps.md) in your pages. The `req` and `res` fields of the [`context`](/docs/api-reference/data-fetching/getInitialProps.md#context-object) object will be empty objects during export as there is no server running.
+- You won't be able to render HTML dynamically when static exporting, as we pre-build the HTML files. Your application can be a hybrid of [Static Generation](/docs/basic-features/pages.md#static-generation) and [Server-Side Rendering](/docs/basic-features/pages.md#server-side-rendering) when you don't use `next export`. You can learn more about it in the [pages section](/docs/basic-features/pages.md).
+- [API Routes](/docs/api-routes/introduction.md) are not supported by this method because they can't be prerendered to HTML.

--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -1,0 +1,76 @@
+---
+description: The Next.js CLI allows you to start, build, and export your application. Learn more about it here.
+---
+
+# Next.js CLI
+
+The Next.js CLI allows you to start, build, and export your application.
+
+To get a list of the available CLI commands, run the following command inside your project directory:
+
+```bash
+npx next -h
+```
+
+_([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher)_
+
+The output should look like this:
+
+```bash
+Usage
+  $ next <command>
+
+Available commands
+  build, start, export, dev, telemetry
+
+Options
+  --version, -v   Version number
+  --help, -h      Displays this message
+
+For more information run a command with the --help flag
+  $ next build --help
+```
+
+You can pass any [node arguments](https://nodejs.org/api/cli.html#cli_node_options_options) to `next` commands:
+
+```bash
+NODE_OPTIONS='--throw-deprecation' next
+NODE_OPTIONS='-r esm' next
+NODE_OPTIONS='--inspect' next
+```
+
+## Build
+
+`next build` creates an optimized production build of your application. The output displays information about each route.
+
+- **Size** – The number of assets downloaded when navigating to the page client-side. The size for each route only includes its dependencies.
+- **First Load JS** – The number of assets downloaded when visiting the page from the server. The amount of JS shared by all is shown as a separate metric.
+
+The first load is colored green, yellow, or red. Aim for green for performant applications.
+
+## Development
+
+`next dev` starts the application in development mode with hot-code reloading, error reporting, and more:
+
+The application will start at `http://localhost:3000` by default. The default port can be changed with `-p`, like so:
+
+```bash
+npx next dev -p 4000
+```
+
+## Production
+
+`next start` starts the application in production mode. The application should be compiled with [`next build`](#build) first.
+
+The application will start at `http://localhost:3000` by default. The default port can be changed with `-p`, like so:
+
+```bash
+npx next start -p 4000
+```
+
+## Telemetry
+
+Next.js collects **completely anonymous** telemetry data about general usage.
+Participation in this anonymous program is optional, and you may opt-out if you'd not like to share any information.
+
+To learn more about Telemetry, [please read this document](https://nextjs.org/telemetry/).

--- a/docs/api-reference/data-fetching/getInitialProps.md
+++ b/docs/api-reference/data-fetching/getInitialProps.md
@@ -1,0 +1,150 @@
+---
+description: Enable Server-Side Rendering in a page and do initial data population with `getInitialProps`.
+---
+
+# getInitialProps
+
+> **Recommended: [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation) or [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering)**
+>
+> If you're using Next.js 9.3 or newer, we recommend that you use `getStaticProps` or `getServerSideProps` instead of `getInitialProps`.
+>
+> These new data fetching methods allow you to have a granular choice between static generation and server-side rendering.
+> Learn more on the documentation for [Pages](/docs/basic-features/pages.md) and [Data fetching](/docs/basic-features/data-fetching.md):
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/data-fetch">Data fetch</a></li>
+  </ul>
+</details>
+
+`getInitialProps` enables [server-side rendering](/docs/basic-features/pages.md#server-side-rendering) in a page and allows you to do **initial data population**, it means sending the [page](/docs/basic-features/pages.md) with the data already populated from the server. This is especially useful for [SEO](https://en.wikipedia.org/wiki/Search_engine_optimization).
+
+> `getInitialProps` will disable [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md).
+
+`getInitialProps` is an [`async`](https://vercel.com/blog/async-and-await) function that can be added to any page as a [`static method`](https://javascript.info/static-properties-methods). Take a look at the following example:
+
+```jsx
+function Page({ stars }) {
+  return <div>Next stars: {stars}</div>;
+}
+
+Page.getInitialProps = async ctx => {
+  const res = await fetch('https://api.github.com/repos/zeit/next.js');
+  const json = await res.json();
+  return { stars: json.stargazers_count };
+};
+
+export default Page;
+```
+
+Or using a class component:
+
+```jsx
+import React from 'react';
+
+class Page extends React.Component {
+  static async getInitialProps(ctx) {
+    const res = await fetch('https://api.github.com/repos/zeit/next.js');
+    const json = await res.json();
+    return { stars: json.stargazers_count };
+  }
+
+  render() {
+    return <div>Next stars: {this.props.stars}</div>;
+  }
+}
+
+export default Page;
+```
+
+`getInitialProps` is used to asynchronously fetch some data, which then populates `props`.
+
+Data returned from `getInitialProps` is serialized when server rendering, similar to what [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) does. Make sure the returned object from `getInitialProps` is a plain `Object` and not using `Date`, `Map` or `Set`.
+
+For the initial page load, `getInitialProps` will run on the server only. `getInitialProps` will then run on the client when navigating to a different route via the [`next/link`](/docs/api-reference/next/link.md) component or by using [`next/router`](/docs/api-reference/next/router.md).
+
+## Context Object
+
+`getInitialProps` receives a single argument called `context`, it's an object with the following properties:
+
+- `pathname` - Current route. That is the path of the page in `/pages`
+- `query` - Query string section of URL parsed as an object
+- `asPath` - `String` of the actual path (including the query) shown in the browser
+- `req` - HTTP request object (server only)
+- `res` - HTTP response object (server only)
+- `err` - Error object if any error is encountered during the rendering
+
+## Caveats
+
+- `getInitialProps` can **not** be used in children components, only in the default export of every page
+- If you are using server-side only modules inside `getInitialProps`, make sure to [import them properly](https://arunoda.me/blog/ssr-and-server-only-modules), otherwise it'll slow down your app
+
+## TypeScript
+
+If you're using TypeScript, you can use the `NextPage` type for function components:
+
+```jsx
+import { NextPage } from 'next';
+
+interface Props {
+  userAgent?: string;
+}
+
+const Page: NextPage<Props> = ({ userAgent }) => <main>Your user agent: {userAgent}</main>;
+
+Page.getInitialProps = async ({ req }) => {
+  const userAgent = req ? req.headers['user-agent'] : navigator.userAgent;
+  return { userAgent };
+};
+
+export default Page;
+```
+
+And for `React.Component`, you can use `NextPageContext`:
+
+```jsx
+import React from 'react';
+import { NextPageContext } from 'next';
+
+interface Props {
+  userAgent?: string;
+}
+
+export default class Page extends React.Component<Props> {
+  static async getInitialProps({ req }: NextPageContext) {
+    const userAgent = req ? req.headers['user-agent'] : navigator.userAgent;
+    return { userAgent };
+  }
+
+  render() {
+    const { userAgent } = this.props;
+    return <main>Your user agent: {userAgent}</main>;
+  }
+}
+```
+
+## Related
+
+For more information on what to do next, we recommend the following sections:
+
+<div class="card">
+  <a href="/docs/basic-features/data-fetching.md">
+    <b>Data Fetching:</b>
+    <small>Learn more about data fetching in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/pages.md">
+    <b>Pages:</b>
+    <small>Learn more about what pages are in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/advanced-features/automatic-static-optimization.md">
+    <b>Automatic Static Optimization:</b>
+    <small>Learn about how Nextjs automatically optimizes your pages.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/build-target.md
+++ b/docs/api-reference/next.config.js/build-target.md
@@ -1,0 +1,47 @@
+---
+description: Learn more about the build targets used by Next.js, which decide the way your application is built and run.
+---
+
+# Build Target
+
+Next.js supports various build targets, each changing the way your application is built and run. We'll explain each of the targets below.
+
+## `server` target
+
+> This is the default target, however, we highly recommend the [`serverless` target](#serverless-target). The `serverless` target enforces [additional constraints](https://rauchg.com/2020/2019-in-review#serverless-upgrades-itself) to keep you in the [Pit of Success](https://blog.codinghorror.com/falling-into-the-pit-of-success/).
+
+This target is compatible with both `next start` and [custom server](/docs/advanced-features/custom-server.md) setups (it's mandatory for a custom server).
+
+Your application will be built and deployed as a monolith. This is the default target and no action is required on your part to opt-in.
+
+## `serverless` target
+
+> Deployments to [Vercel](https://vercel.com) will automatically enable this target. You should not opt-into it yourself.
+
+This target will output independent pages that don't require a monolithic server.
+
+It's only compatible with `next start` or Serverless deployment platforms (like [Vercel](https://vercel.com)) — you cannot use the custom server API.
+
+To opt-into this target, set the following configuration in your `next.config.js`:
+
+```js
+module.exports = {
+  target: 'serverless'
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/deployment.md">
+    <b>Deployment:</b>
+    <small>Compile and deploy your Next.js app to production.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/cdn-support-with-asset-prefix.md
+++ b/docs/api-reference/next.config.js/cdn-support-with-asset-prefix.md
@@ -1,0 +1,36 @@
+---
+description: A custom asset prefix allows you serve static assets from a CDN. Learn more about it here.
+---
+
+# CDN Support with Asset Prefix
+
+To set up a [CDN](https://en.wikipedia.org/wiki/Content_delivery_network), you can set up an asset prefix and configure your CDN's origin to resolve to the domain that Next.js is hosted on.
+
+Open `next.config.js` and add the `assetPrefix` config:
+
+```js
+const isProd = process.env.NODE_ENV === 'production';
+
+module.exports = {
+  // Use the CDN in production and localhost for development.
+  assetPrefix: isProd ? 'https://cdn.mydomain.com' : ''
+};
+```
+
+Next.js will automatically use your prefix in the scripts it loads, but this has no effect whatsoever on the [public](/docs/basic-features/static-file-serving.md) folder; if you want to serve those assets over a CDN, you'll have to introduce the prefix yourself. One way of introducing a prefix that works inside your components and varies by environment is documented [in this example](https://github.com/zeit/next.js/tree/canary/examples/with-universal-configuration-build-time).
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/static-file-serving.md">
+    <b>Static File Serving:</b>
+    <small>Serve static files, like images, in the public directory.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/compression.md
+++ b/docs/api-reference/next.config.js/compression.md
@@ -1,0 +1,24 @@
+---
+description: Next.js provides gzip compression to compress rendered content and static files, it only works with the server target. Learn more about it here.
+---
+
+# Compression
+
+Next.js provides [**gzip**](https://tools.ietf.org/html/rfc6713#section-3) compression to compress rendered content and static files. Compression only works with the [`server` target](/docs/api-reference/next.config.js/build-target.md#server-target). In general you will want to enable compression on a HTTP proxy like [nginx](https://www.nginx.com/), to offload load from the `Node.js` process.
+
+To disable **compression**, open `next.config.js` and disable the `compress` config:
+
+```js
+module.exports = {
+  compress: false
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/configuring-onDemandEntries.md
+++ b/docs/api-reference/next.config.js/configuring-onDemandEntries.md
@@ -1,0 +1,29 @@
+---
+description: Configure how Next.js will dispose and keep in memory pages created in development.
+---
+
+# Configuring onDemandEntries
+
+Next.js exposes some options that give you some control over how the server will dispose or keep in memory built pages in development.
+
+To change the defaults, open `next.config.js` and add the `onDemandEntries` config:
+
+```js
+module.exports = {
+  onDemandEntries: {
+    // period (in ms) where the server will keep pages in the buffer
+    maxInactiveAge: 25 * 1000,
+    // number of pages that should be kept simultaneously without being disposed
+    pagesBufferLength: 2
+  }
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/configuring-the-build-id.md
+++ b/docs/api-reference/next.config.js/configuring-the-build-id.md
@@ -1,0 +1,27 @@
+---
+description: Configure the build id, which is used to identify the current build in which your application is being served.
+---
+
+# Configuring the Build ID
+
+Next.js uses a constant id generated at build time to identify which version of your application is being served. This can cause problems in multi-server deployments when `next build` is ran on every server. In order to keep a static build id between builds you can provide your own build id.
+
+Open `next.config.js` and add the `generateBuildId` function:
+
+```js
+module.exports = {
+  generateBuildId: async () => {
+    // You can, for example, get the latest git commit hash here
+    return 'my-build-id';
+  }
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/custom-page-extensions.md
+++ b/docs/api-reference/next.config.js/custom-page-extensions.md
@@ -1,0 +1,24 @@
+---
+description: Extend the default page extensions used by Next.js when resolving pages in the pages directory.
+---
+
+# Custom Page Extensions
+
+Aimed at modules like [@next/mdx](https://github.com/zeit/next.js/tree/canary/packages/next-mdx), which adds support for pages ending with `.mdx`. You can configure the extensions looked for in the `pages` directory when resolving pages.
+
+Open `next.config.js` and add the `pageExtensions` config:
+
+```js
+module.exports = {
+  pageExtensions: ['mdx', 'jsx', 'js', 'ts', 'tsx']
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/custom-webpack-config.md
+++ b/docs/api-reference/next.config.js/custom-webpack-config.md
@@ -1,0 +1,76 @@
+---
+description: Extend the default webpack config added by Next.js.
+---
+
+# Custom Webpack Config
+
+Some commonly asked for features are available as plugins:
+
+- [@zeit/next-sass](https://github.com/zeit/next-plugins/tree/master/packages/next-sass)
+- [@zeit/next-less](https://github.com/zeit/next-plugins/tree/master/packages/next-less)
+- [@zeit/next-stylus](https://github.com/zeit/next-plugins/tree/master/packages/next-stylus)
+- [@zeit/next-preact](https://github.com/zeit/next-plugins/tree/master/packages/next-preact)
+- [@next/mdx](https://github.com/zeit/next.js/tree/canary/packages/next-mdx)
+- [@next/bundle-analyzer](https://github.com/zeit/next.js/tree/canary/packages/next-bundle-analyzer)
+
+In order to extend our usage of `webpack`, you can define a function that extends its config inside `next.config.js`, like so:
+
+```js
+module.exports = {
+  webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
+    // Note: we provide webpack above so you should not `require` it
+    // Perform customizations to webpack config
+    // Important: return the modified config
+    config.plugins.push(new webpack.IgnorePlugin(/\/__tests__\//));
+    return config;
+  },
+  webpackDevMiddleware: config => {
+    // Perform customizations to webpack dev middleware config
+    // Important: return the modified config
+    return config;
+  }
+};
+```
+
+> The `webpack` function is executed twice, once for the server and once for the client. This allows you to distinguish between client and server configuration using the `isServer` property.
+
+The second argument to the `webpack` function is an object with the following properties:
+
+- `buildId`: `String` - The build id, used as a unique identifier between builds
+- `dev`: `Boolean` - Indicates if the compilation will be done in development
+- `isServer`: `Boolean` - It's `true` for server-side compilation, and `false` for client-side compilation
+- `defaultLoaders`: `Object` - Default loaders used internally by Next.js:
+  - `babel`: `Object` - Default `babel-loader` configuration
+
+Example usage of `defaultLoaders.babel`:
+
+```js
+// Example config for adding a loader that depends on babel-loader
+// This source was taken from the @next/mdx plugin source:
+// https://github.com/zeit/next.js/tree/canary/packages/next-mdx
+module.exports = {
+  webpack: (config, options) => {
+    config.module.rules.push({
+      test: /\.mdx/,
+      use: [
+        options.defaultLoaders.babel,
+        {
+          loader: '@mdx-js/loader',
+          options: pluginOptions.options
+        }
+      ]
+    });
+
+    return config;
+  }
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/disabling-etag-generation.md
+++ b/docs/api-reference/next.config.js/disabling-etag-generation.md
@@ -1,0 +1,24 @@
+---
+description: Next.js will generate etags for every page by default. Learn more about how to disable etag generation here.
+---
+
+# Disabling ETag Generation
+
+Next.js will generate [etags](https://en.wikipedia.org/wiki/HTTP_ETag) for every page by default. You may want to disable etag generation for HTML pages depending on your cache strategy.
+
+Open `next.config.js` and disable the `generateEtags` option:
+
+```js
+module.exports = {
+  generateEtags: false
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/disabling-x-powered-by.md
+++ b/docs/api-reference/next.config.js/disabling-x-powered-by.md
@@ -1,0 +1,22 @@
+---
+description: Next.js will add the `x-powered-by` header by default. Learn to opt-out of it here.
+---
+
+# Disabling x-powered-by
+
+By default Next.js will add the `x-powered-by` header. To opt-out of it, open `next.config.js` and disable the `poweredByHeader` config:
+
+```js
+module.exports = {
+  poweredByHeader: false
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/environment-variables.md
+++ b/docs/api-reference/next.config.js/environment-variables.md
@@ -1,0 +1,65 @@
+---
+description: Learn to add and access environment variables in your Next.js application at build time.
+---
+
+# Environment Variables
+
+> Since the release of Next.js 9.4 we now have a more intuitive and ergonomic experience for [adding environment variables](/docs/basic-features/environment-variables.md). Give it a try!
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-env-from-next-config-js">With env</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-now-env">With Now env</a></li>
+  </ul>
+</details>
+
+To add environment variables to the JavaScript bundle, open `next.config.js` and add the `env` config:
+
+```js
+module.exports = {
+  env: {
+    customKey: 'my-value'
+  }
+};
+```
+
+Now you can access `process.env.customKey` in your code. For example:
+
+```jsx
+function Page() {
+  return <h1>The value of customKey is: {process.env.customKey}</h1>;
+}
+
+export default Page;
+```
+
+Next.js will replace `process.env.customKey` with `'my-value'` at build time. Trying to destructure `process.env` variables won't work due to the nature of webpack [DefinePlugin](https://webpack.js.org/plugins/define-plugin/).
+
+For example, the following line:
+
+```jsx
+return <h1>The value of customKey is: {process.env.customKey}</h1>;
+```
+
+Will end up being:
+
+```jsx
+return <h1>The value of customKey is: {'my-value'}</h1>;
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/environment-variables.md">
+    <b>Built-in support for Environment Variables:</b>
+    <small>Learn more about the new support for environment variables.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/exportPathMap.md
+++ b/docs/api-reference/next.config.js/exportPathMap.md
@@ -1,0 +1,81 @@
+---
+description: Customize the pages that will be exported as HTML files when using `next export`.
+---
+
+# exportPathMap
+
+> This feature is exclusive of `next export`. Please refer to [Static HTML export](/docs/advanced-features/static-html-export.md) if you want to learn more about it.
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-static-export">Static Export</a></li>
+  </ul>
+</details>
+
+Let's start with an example, to create a custom `exportPathMap` for an app with the following pages:
+
+- `pages/index.js`
+- `pages/about.js`
+- `pages/post.js`
+
+Open `next.config.js` and add the following `exportPathMap` config:
+
+```js
+module.exports = {
+  exportPathMap: async function (defaultPathMap, { dev, dir, outDir, distDir, buildId }) {
+    return {
+      '/': { page: '/' },
+      '/about': { page: '/about' },
+      '/p/hello-nextjs': { page: '/post', query: { title: 'hello-nextjs' } },
+      '/p/learn-nextjs': { page: '/post', query: { title: 'learn-nextjs' } },
+      '/p/deploy-nextjs': { page: '/post', query: { title: 'deploy-nextjs' } }
+    };
+  }
+};
+```
+
+The pages will then be exported as HTML files, for example, `/about` will become `/about.html`.
+
+`exportPathMap` is an `async` function that receives 2 arguments: the first one is `defaultPathMap`, which is the default map used by Next.js. The second argument is an object with:
+
+- `dev` - `true` when `exportPathMap` is being called in development. `false` when running `next export`. In development `exportPathMap` is used to define routes.
+- `dir` - Absolute path to the project directory
+- `outDir` - Absolute path to the `out/` directory (configurable with `-o`). When `dev` is `true` the value of `outDir` will be `null`.
+- `distDir` - Absolute path to the `.next/` directory (configurable with the [`distDir`](/docs/api-reference/next.config.js/setting-a-custom-build-directory.md) config)
+- `buildId` - The generated build id
+
+The returned object is a map of pages where the `key` is the `pathname` and the `value` is an object that accepts the following fields:
+
+- `page`: `String` - the page inside the `pages` directory to render
+- `query`: `Object` - the `query` object passed to `getInitialProps` when prerendering. Defaults to `{}`
+
+> The exported `pathname` can also be a filename (for example, `/readme.md`), but you may need to set the `Content-Type` header to `text/html` when serving its content if it is different than `.html`.
+
+## Adding a trailing slash
+
+It is possible to configure Next.js to export pages as `index.html` files and require trailing slashes, `/about` becomes `/about/index.html` and is routable via `/about/`. This was the default behavior prior to Next.js 9.
+
+To switch back and add a trailing slash, open `next.config.js` and enable the `exportTrailingSlash` config:
+
+```js
+module.exports = {
+  exportTrailingSlash: true
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/advanced-features/static-html-export.md">
+    <b>Static HTML Export:</b>
+    <small>Export your Next.js app to static HTML.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/ignoring-typescript-errors.md
+++ b/docs/api-reference/next.config.js/ignoring-typescript-errors.md
@@ -1,0 +1,41 @@
+---
+description: Next.js reports TypeScript errors by default. Learn to opt-out of this behavior here.
+---
+
+# Ignoring TypeScript Errors
+
+Next.js fails your **production build** (`next build`) when TypeScript errors are present in your project.
+
+If you'd like Next.js to dangerously produce production code even when your application has errors, you can disable the built-in type checking step.
+
+> Be sure you are running type checks as part of your build or deploy process, otherwise this can be very dangerous.
+
+Open `next.config.js` and enable the `ignoreBuildErrors` option in the `typescript` config:
+
+```js
+module.exports = {
+  typescript: {
+    // !! WARN !!
+    // Dangerously allow production builds to successfully complete even if
+    // your project has type errors.
+    // !! WARN !!
+    ignoreBuildErrors: true
+  }
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/typescript.md">
+    <b>TypeScript:</b>
+    <small>Get started with TypeScript in Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/introduction.md
+++ b/docs/api-reference/next.config.js/introduction.md
@@ -1,0 +1,51 @@
+---
+description: learn more about the configuration file used by Next.js to handle your application.
+---
+
+# next.config.js
+
+For custom advanced behavior of Next.js, you can create a `next.config.js` in the root of your project directory (next to `package.json`).
+
+`next.config.js` is a regular Node.js module, not a JSON file. It gets used by the Next.js server and build phases, and it's not included in the browser build.
+
+Take a look at the following `next.config.js` example:
+
+```js
+module.exports = {
+  /* config options here */
+};
+```
+
+You can also use a function:
+
+```js
+module.exports = (phase, { defaultConfig }) => {
+  return {
+    /* config options here */
+  };
+};
+```
+
+`phase` is the current context in which the configuration is loaded. You can see the available phases [here](https://github.com/zeit/next.js/blob/canary/packages/next/next-server/lib/constants.ts#L1-L4). Phases can be imported from `next/constants`:
+
+```js
+const { PHASE_DEVELOPMENT_SERVER } = require('next/constants');
+
+module.exports = (phase, { defaultConfig }) => {
+  if (phase === PHASE_DEVELOPMENT_SERVER) {
+    return {
+      /* development only config options here */
+    };
+  }
+
+  return {
+    /* config options for all phases except development here */
+  };
+};
+```
+
+The commented lines are the place where you can put the configs allowed by `next.config.js`, which are defined [here](https://github.com/zeit/next.js/blob/canary/packages/next/next-server/server/config.ts#L12-L63).
+
+However, none of the configs are required, and it's not necessary to understand what each config does, instead, search for the features you need to enable or modify in this section and they will show you what to do.
+
+> Avoid using new JavaScript features not available in your target Node.js version. `next.config.js` will not be parsed by Webpack, Babel or TypeScript.

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -1,0 +1,70 @@
+---
+description: Add client and server runtime configuration to your Next.js app.
+---
+
+# Runtime Configuration
+
+> Generally you'll want to use [build-time environment variables](/docs/api-reference/next.config.js/environment-variables.md) to provide your configuration. The reason for this is that runtime configuration adds rendering / initialization overhead and is incompatible with [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md).
+
+> Runtime configuration is not available when using the [`serverless` target](/docs/api-reference/next.config.js/build-target.md#serverless-target).
+
+To add runtime configuration to your app open `next.config.js` and add the `publicRuntimeConfig` and `serverRuntimeConfig` configs:
+
+```js
+module.exports = {
+  serverRuntimeConfig: {
+    // Will only be available on the server side
+    mySecret: 'secret',
+    secondSecret: process.env.SECOND_SECRET // Pass through env variables
+  },
+  publicRuntimeConfig: {
+    // Will be available on both server and client
+    staticFolder: '/static'
+  }
+};
+```
+
+Place any server-only runtime config under `serverRuntimeConfig`.
+
+Anything accessible to both client and server-side code should be under `publicRuntimeConfig`.
+
+> A page that relies on `publicRuntimeConfig` **must** use `getInitialProps` to opt-out of [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md). Runtime configuration won't be available to any page (or component in a page) without `getInitialProps`.
+
+To get access to the runtime configs in your app use `next/config`, like so:
+
+```jsx
+import getConfig from 'next/config';
+
+// Only holds serverRuntimeConfig and publicRuntimeConfig
+const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
+// Will only be available on the server-side
+console.log(serverRuntimeConfig.mySecret);
+// Will be available on both server-side and client-side
+console.log(publicRuntimeConfig.staticFolder);
+
+function MyImage() {
+  return (
+    <div>
+      <img src={`${publicRuntimeConfig.staticFolder}/logo.png`} alt="logo" />
+    </div>
+  );
+}
+
+export default MyImage;
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/environment-variables.md">
+    <b>Environment Variables:</b>
+    <small>Access environment variables in your Next.js application at build time.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/setting-a-custom-build-directory.md
+++ b/docs/api-reference/next.config.js/setting-a-custom-build-directory.md
@@ -1,0 +1,28 @@
+---
+description: Set a custom build directory to use instead of the default .next directory.
+---
+
+# Setting a custom build directory
+
+You can specify a name to use for a custom build directory to use instead of `.next`.
+
+Open `next.config.js` and add the `distDir` config:
+
+```js
+module.exports = {
+  distDir: 'build'
+};
+```
+
+Now if you run `next build` Next.js will use `build` instead of the default `.next` folder.
+
+> `distDir` **should not** leave your project directory. For example, `../build` is an **invalid** directory.
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/static-optimization-indicator.md
+++ b/docs/api-reference/next.config.js/static-optimization-indicator.md
@@ -1,0 +1,35 @@
+---
+description: Optimized pages include an indicator to let you know if it's being statically optimized. You can opt-out of it here.
+---
+
+# Static Optimization Indicator
+
+When a page qualifies for [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) we show an indicator to let you know.
+
+This is helpful since automatic static optimization can be very beneficial and knowing immediately in development if the page qualifies can be useful.
+
+In some cases this indicator might not be useful, like when working on electron applications. To remove it open `next.config.js` and disable the `autoPrerender` config in `devIndicators`:
+
+```js
+module.exports = {
+  devIndicators: {
+    autoPrerender: false
+  }
+};
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/advanced-features/automatic-static-optimization.md">
+    <b>Automatic Static Optimization:</b>
+    <small>Next.js automatically optimizes your app to be static HTML whenever possible. Learn how it works here.</small>
+  </a>
+</div>

--- a/docs/api-reference/next/amp.md
+++ b/docs/api-reference/next/amp.md
@@ -1,0 +1,87 @@
+---
+description: Enable AMP in a page, and control the way Next.js adds AMP to the page with the AMP config.
+---
+
+# next/amp
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/amp">AMP</a></li>
+  </ul>
+</details>
+
+> AMP support is one of our advanced features, you can read more about it [here](/docs/advanced-features/amp-support/introduction.md).
+
+To enable AMP, add the following config to your page:
+
+```jsx
+export const config = { amp: true };
+```
+
+The `amp` config accepts the following values:
+
+- `true` - The page will be AMP-only
+- `'hybrid'` - The page will have two versions, one with AMP and another one with HTML
+
+To learn more about the `amp` config, read the sections below.
+
+## AMP First Page
+
+Take a look at the following example:
+
+```jsx
+export const config = { amp: true };
+
+function About(props) {
+  return <h3>My AMP About Page!</h3>;
+}
+
+export default About;
+```
+
+The page above is an AMP-only page, which means:
+
+- The page has no Next.js or React client-side runtime
+- The page is automatically optimized with [AMP Optimizer](https://github.com/ampproject/amp-toolbox/tree/master/packages/optimizer), an optimizer that applies the same transformations as AMP caches (improves performance by up to 42%)
+- The page has an user-accessible (optimized) version of the page and a search-engine indexable (unoptimized) version of the page
+
+## Hybrid AMP Page
+
+Take a look at the following example:
+
+```jsx
+import { useAmp } from 'next/amp';
+
+export const config = { amp: 'hybrid' };
+
+function About(props) {
+  const isAmp = useAmp();
+
+  return (
+    <div>
+      <h3>My AMP About Page!</h3>
+      {isAmp ? (
+        <amp-img
+          width="300"
+          height="300"
+          src="/my-img.jpg"
+          alt="a cool image"
+          layout="responsive"
+        />
+      ) : (
+        <img width="300" height="300" src="/my-img.jpg" alt="a cool image" />
+      )}
+    </div>
+  );
+}
+
+export default About;
+```
+
+The page above is a hybrid AMP page, which means:
+
+- The page is rendered as traditional HTML (default) and AMP HTML (by adding `?amp=1` to the URL)
+- The AMP version of the page only has valid optimizations applied with AMP Optimizer so that it is indexable by search-engines
+
+The page uses `useAmp` to differentiate between modes, it's a [React Hook](https://reactjs.org/docs/hooks-intro.html) that returns `true` if the page is using AMP, and `false` otherwise.

--- a/docs/api-reference/next/head.md
+++ b/docs/api-reference/next/head.md
@@ -1,0 +1,63 @@
+---
+description: Add custom elements to the `head` of your page with the built-in Head component.
+---
+
+# next/head
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/head-elements">Head Elements</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/layout-component">Layout Component</a></li>
+  </ul>
+</details>
+
+We expose a built-in component for appending elements to the `head` of the page:
+
+```jsx
+import Head from 'next/head';
+
+function IndexPage() {
+  return (
+    <div>
+      <Head>
+        <title>My page title</title>
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      </Head>
+      <p>Hello world!</p>
+    </div>
+  );
+}
+
+export default IndexPage;
+```
+
+To avoid duplicate tags in your `head` you can use the `key` property, which will make sure the tag is only rendered once, as in the following example:
+
+```jsx
+import Head from 'next/head';
+
+function IndexPage() {
+  return (
+    <div>
+      <Head>
+        <title>My page title</title>
+        <meta property="og:title" content="My page title" key="title" />
+      </Head>
+      <Head>
+        <meta property="og:title" content="My new title" key="title" />
+      </Head>
+      <p>Hello world!</p>
+    </div>
+  );
+}
+
+export default IndexPage;
+```
+
+In this case only the second `<meta property="og:title" />` is rendered. `meta` tags with duplicate `name` attributes are automatically handled.
+
+> The contents of `head` get cleared upon unmounting the component, so make sure each page completely defines what it needs in `head`, without making assumptions about what other pages added.
+
+`title`, `meta` or any other elements (e.g. `script`) need to be contained as **direct** children of the `Head` element,
+or wrapped into maximum one level of `<React.Fragment>` or arrays—otherwise the tags won't be correctly picked up on client-side navigations.

--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -1,0 +1,185 @@
+---
+description: Enable client-side transitions between routes with the built-in Link component.
+---
+
+# next/link
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/hello-world">Hello World</a></li>
+  </ul>
+</details>
+
+> Before moving forward, we recommend you to read [Routing Introduction](/docs/routing/introduction.md) first.
+
+Client-side transitions between routes can be enabled via the `Link` component exported by `next/link`.
+
+An example of linking to `/` and `/about`:
+
+```jsx
+import Link from 'next/link';
+
+function Home() {
+  return (
+    <ul>
+      <li>
+        <Link href="/">
+          <a>Home</a>
+        </Link>
+      </li>
+      <li>
+        <Link href="/about">
+          <a>About Us</a>
+        </Link>
+      </li>
+    </ul>
+  );
+}
+
+export default Home;
+```
+
+`Link` accepts the following props:
+
+- `href` - The path inside `pages` directory. This is the only required prop
+- `as` - The path that will be rendered in the browser URL bar. Used for dynamic routes
+- [`passHref`](#forcing-Link-to-expose-href-to-its-child) - Forces `Link` to send the `href` property to its child. Defaults to `false`
+- `prefetch` - Prefetch the page in the background. Defaults to `true`. Any `<Link />` that is in the viewport (initially or through scroll) will be preloaded. Pages using [Static Generation](/docs/basic-features/data-fetching#getstaticprops-static-generation) will preload `JSON` files with the data for faster page transitions.
+- [`replace`](#replace-the-url-instead-of-push) - Replace the current `history` state instead of adding a new url into the stack. Defaults to `false`
+- [`scroll`](#disable-scrolling-to-the-top-of-the-page) - Scroll to the top of the page after a navigation. Defaults to `true`
+- [`shallow`](/docs/routing/shallow-routing.md) - Update the path of the current page without rerunning [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation), [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering) or [`getInitialProps`](/docs/api-reference/data-fetching/getInitialProps.md). Defaults to `false`
+
+External URLs, and any links that don't require a route navigation using `/pages`, don't need to be handled with `Link`; use the anchor tag for such cases instead.
+
+## Dynamic routes
+
+A `Link` to a dynamic route is a combination of the `href` and `as` props. A link to the page `pages/post/[pid].js` will look like this:
+
+```jsx
+<Link href="/post/[pid]" as="/post/abc">
+  <a>First Post</a>
+</Link>
+```
+
+`href` is a file system path used by the page and it shouldn't change at runtime. `as` on the other hand, will be dynamic most of the time according to your needs. Here's an example of how to create a list of links:
+
+```jsx
+const pids = ['id1', 'id2', 'id3'];
+{
+  pids.map(pid => (
+    <Link href="/post/[pid]" as={`/post/${pid}`}>
+      <a>Post {pid}</a>
+    </Link>
+  ));
+}
+```
+
+## If the child is a custom component that wraps an `<a>` tag
+
+If the child of `Link` is a custom component that wraps an `<a>` tag, you must add `passHref` to `Link`. This is necessary if you’re using libraries like [styled-components](https://styled-components.com/). Without this, the `<a>` tag will not have the `href` attribute, which might hurt your site’s SEO.
+
+```jsx
+import Link from 'next/link';
+import styled from 'styled-components';
+
+// This creates a custom component that wraps an <a> tag
+const RedLink = styled.a`
+  color: red;
+`;
+
+function NavLink({ href, name }) {
+  // Must add passHref to Link
+  return (
+    <Link href={href} passHref>
+      <RedLink>{name}</RedLink>
+    </Link>
+  );
+}
+
+export default NavLink;
+```
+
+> **Note**: If you’re using [emotion](https://emotion.sh/)’s JSX pragma feature (`@jsx jsx`), you must use `passHref` even if you use an `<a>` tag directly.
+
+## If the child is a function component
+
+If the child of `Link` is a function component, in addition to using `passHref`, you must wrap the component in [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref):
+
+```jsx
+import Link from 'next/link';
+
+// `onClick`, `href`, and `ref` need to be passed to the DOM element
+// for proper handling
+const MyButton = React.forwardRef(({ onClick, href }, ref) => {
+  return (
+    <a href={href} onClick={onClick} ref={ref}>
+      Click Me
+    </a>
+  );
+});
+
+function Home() {
+  return (
+    <Link href="/about" passHref>
+      <MyButton />
+    </Link>
+  );
+}
+
+export default Home;
+```
+
+## With URL Object
+
+`Link` can also receive an URL object and it will automatically format it to create the URL string. Here's how to do it:
+
+```jsx
+import Link from 'next/link';
+
+function Home() {
+  return (
+    <div>
+      <Link href={{ pathname: '/about', query: { name: 'test' } }}>
+        <a>About us</a>
+      </Link>
+    </div>
+  );
+}
+
+export default Home;
+```
+
+The above example will be a link to `/about?name=test`. You can use every property as defined in the [Node.js URL module documentation](https://nodejs.org/api/url.html#url_url_strings_and_url_objects).
+
+## Replace the URL instead of push
+
+The default behavior of the `Link` component is to `push` a new URL into the `history` stack. You can use the `replace` prop to prevent adding a new entry, as in the following example:
+
+```jsx
+<Link href="/about" replace>
+  <a>About us</a>
+</Link>
+```
+
+## Using a component that supports `onClick`
+
+`Link` supports any component that supports the `onClick` event, in the case you don't provide an `<a>` tag, consider the following example:
+
+```jsx
+<Link href="/about">
+  <img src="/static/image.png" alt="image" />
+</Link>
+```
+
+The child of `Link` is `<img>` instead of `<a>`. `Link` will send the `onClick` property to `<img>` but won't pass the `href` property.
+
+## Disable scrolling to the top of the page
+
+The default behavior of `Link` is to scroll to the top of the page. When there is a hash defined it will scroll to the specific id, like a normal `<a>` tag. To prevent scrolling to the top / hash `scroll={false}` can be added to `Link`:
+
+```jsx
+<Link href="/?counter=10" scroll={false}>
+  <a>Disables scrolling to the top</a>
+</Link>
+```

--- a/docs/api-reference/next/router.md
+++ b/docs/api-reference/next/router.md
@@ -1,0 +1,322 @@
+---
+description: Learn more about the API of the Next.js Router, and access the router instance in your page with the useRouter hook.
+---
+
+# next/router
+
+> Before moving forward, we recommend you to read [Routing Introduction](/docs/routing/introduction.md) first.
+
+## useRouter
+
+If you want to access the [`router` object](#router-object) inside any function component in your app, you can use the `useRouter` hook, take a look at the following example:
+
+```jsx
+import { useRouter } from 'next/router';
+
+function ActiveLink({ children, href }) {
+  const router = useRouter();
+  const style = {
+    marginRight: 10,
+    color: router.pathname === href ? 'red' : 'black'
+  };
+
+  const handleClick = e => {
+    e.preventDefault();
+    router.push(href);
+  };
+
+  return (
+    <a href={href} onClick={handleClick} style={style}>
+      {children}
+    </a>
+  );
+}
+
+export default ActiveLink;
+```
+
+> `useRouter` is a [React Hook](https://reactjs.org/docs/hooks-intro.html), meaning it cannot be used with classes. You can either use [withRouter](#withRouter) or wrap your class in a function component.
+
+### router object
+
+The following is the definition of the `router` object returned by both [`useRouter`](#useRouter) and [`withRouter`](#withRouter):
+
+- `pathname`: `String` - Current route. That is the path of the page in `/pages`
+- `query`: `Object` - The query string parsed to an object. It will be an empty object during prerendering if the page doesn't have [data fetching requirements](/docs/basic-features/data-fetching.md). Defaults to `{}`
+- `asPath`: `String` - Actual path (including the query) shown in the browser
+
+Additionally, the [`Router API`](#router-api) is also included inside the object.
+
+## withRouter
+
+If [`useRouter`](#useRouter) is not the best fit for you, `withRouter` can also add the same [`router` object](#router-object) to any component, here's how to use it:
+
+```jsx
+import { withRouter } from 'next/router';
+
+function Page({ router }) {
+  return <p>{router.pathname}</p>;
+}
+
+export default withRouter(Page);
+```
+
+## Router API
+
+The API of `Router`, exported by `next/router`, is defined below.
+
+### Router.push
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/using-router">Using Router</a></li>
+  </ul>
+</details>
+
+Handles client-side transitions, this method is useful for cases where [`next/link`](/docs/api-reference/next/link.md) is not enough.
+
+```jsx
+import Router from 'next/router';
+
+Router.push(url, as, options);
+```
+
+- `url` - The URL to navigate to. This is usually the name of a `page`
+- `as` - Optional decorator for the URL that will be shown in the browser. Defaults to `url`
+- `options` - Optional object with the following configuration options:
+  - [`shallow`](/docs/routing/shallow-routing.md): Update the path of the current page without rerunning [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation), [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering) or [`getInitialProps`](/docs/api-reference/data-fetching/getInitialProps.md). Defaults to `false`
+
+> You don't need to use `Router` for external URLs, [window.location](https://developer.mozilla.org/en-US/docs/Web/API/Window/location) is better suited for those cases.
+
+#### Usage
+
+Navigating to `pages/about.js`, which is a predefined route:
+
+```jsx
+import Router from 'next/router';
+
+function Page() {
+  return <span onClick={() => Router.push('/about')}>Click me</span>;
+}
+```
+
+Navigating `pages/post/[pid].js`, which is a dynamic route:
+
+```jsx
+import Router from 'next/router';
+
+function Page() {
+  return <span onClick={() => Router.push('/post/[pid]', '/post/abc')}>Click me</span>;
+}
+```
+
+#### With URL object
+
+You can use an URL object in the same way you can use it for [`next/link`](/docs/api-reference/next/link.md#with-url-object). Works for both the `url` and `as` parameters:
+
+```jsx
+import Router from 'next/router';
+
+const handler = () => {
+  Router.push({
+    pathname: '/about',
+    query: { name: 'Vercel' }
+  });
+};
+
+function ReadMore() {
+  return (
+    <div>
+      Click <span onClick={handler}>here</span> to read more
+    </div>
+  );
+}
+
+export default ReadMore;
+```
+
+### Router.replace
+
+Similar to the `replace` prop in [`next/link`](/docs/api-reference/next/link.md), `Router.replace` will prevent adding a new URL entry into the `history` stack, take a look at the following example:
+
+```jsx
+import Router from 'next/router';
+
+Router.replace('/home');
+```
+
+The API for `Router.replace` is exactly the same as that used for [`Router.push`](#router.push).
+
+### Router.prefetch
+
+Prefetch pages for faster client-side transitions. This method is only useful for navigations without [`next/link`](/docs/api-reference/next/link.md), as `next/link` takes care of prefetching pages automatically.
+
+> This is a production only feature. Next.js doesn't prefetch pages on development.
+
+```jsx
+import Router from 'next/router';
+
+Router.prefetch(url, as);
+```
+
+- `url` - The path to a `page` inside the `pages` directory
+- `as` - Optional decorator for `url`, used to prefetch [dynamic routes](/docs/routing/dynamic-routes). Defaults to `url`
+
+#### Usage
+
+Let's say you have a login page, and after a login, you redirect the user to the dashboard. For that case, we can prefetch the dashboard to make a faster transition, like in the following example:
+
+```jsx
+import { useCallback, useEffect } from 'react';
+import Router from 'next/router';
+
+export default function Login() {
+  const handleSubmit = useCallback(e => {
+    e.preventDefault();
+
+    fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        /* Form data */
+      })
+    }).then(res => {
+      // Do a fast client-side transition to the already prefetched dashboard page
+      if (res.ok) Router.push('/dashboard');
+    });
+  }, []);
+
+  useEffect(() => {
+    // Prefetch the dashboard page as the user will go there after the login
+    Router.prefetch('/dashboard');
+  }, []);
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {/* Form fields */}
+      <button type="submit">Login</button>
+    </form>
+  );
+}
+```
+
+### Router.beforePopState
+
+In some cases (for example, if using a [Custom Server](/docs/advanced-features/custom-server.md)), you may wish to listen to [popstate](https://developer.mozilla.org/en-US/docs/Web/Events/popstate) and do something before the router acts on it.
+
+You could use this to manipulate the request, or force a SSR refresh, as in the following example:
+
+```jsx
+import Router from 'next/router';
+
+Router.beforePopState(({ url, as, options }) => {
+  // I only want to allow these two routes!
+  if (as !== '/' && as !== '/other') {
+    // Have SSR render bad routes as a 404.
+    window.location.href = as;
+    return false;
+  }
+
+  return true;
+});
+```
+
+`Router.beforePopState(cb: () => boolean)`
+
+- `cb` - The function to run on incoming `popstate` events. The function receives the state of the event as an object with the following props:
+  - `url`: `String` - the route for the new state. This is usually the name of a `page`
+  - `as`: `String` - the url that will be shown in the browser
+  - `options`: `Object` - Additional options sent by [Router.push](#router.push)
+
+If the function you pass into `beforePopState` returns `false`, `Router` will not handle `popstate` and you'll be responsible for handling it, in that case. See [Disabling file-system routing](/docs/advanced-features/custom-server.md#disabling-file-system-routing).
+
+### Router.back
+
+Navigate back in history. Equivalent to clicking the browser’s back button. It executes `window.history.back()`.
+
+```jsx
+import Router from 'next/router';
+
+Router.back();
+```
+
+### Router.reload
+
+Reload the current URL. Equivalent to clicking the browser’s refresh button. It executes `window.location.reload()`.
+
+```jsx
+import Router from 'next/router';
+
+Router.reload();
+```
+
+### Router.events
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-loading">With a page loading indicator</a></li>
+  </ul>
+</details>
+
+You can listen to different events happening inside the Router. Here's a list of supported events:
+
+- `routeChangeStart(url)` - Fires when a route starts to change
+- `routeChangeComplete(url)` - Fires when a route changed completely
+- `routeChangeError(err, url)` - Fires when there's an error when changing routes, or a route load is cancelled
+  - `err.cancelled` - Indicates if the navigation was cancelled
+- `beforeHistoryChange(url)` - Fires just before changing the browser's history
+- `hashChangeStart(url)` - Fires when the hash will change but not the page
+- `hashChangeComplete(url)` - Fires when the hash has changed but not the page
+
+> Here `url` is the URL shown in the browser. If you call `Router.push(url, as)` (or similar), then the value of `url` will be `as`.
+
+For example, to listen to the router event `routeChangeStart`, do the following:
+
+```jsx
+import Router from 'next/router';
+
+const handleRouteChange = url => {
+  console.log('App is changing to: ', url);
+};
+
+Router.events.on('routeChangeStart', handleRouteChange);
+```
+
+If you no longer want to listen to the event, unsubscribe with the `off` method:
+
+```jsx
+import Router from 'next/router';
+
+Router.events.off('routeChangeStart', handleRouteChange);
+```
+
+If a route load is cancelled (for example, by clicking two links rapidly in succession), `routeChangeError` will fire. And the passed `err` will contain a `cancelled` property set to `true`, as in the following example:
+
+```jsx
+import Router from 'next/router';
+
+Router.events.on('routeChangeError', (err, url) => {
+  if (err.cancelled) {
+    console.log(`Route to ${url} was cancelled!`);
+  }
+});
+```
+
+Router events should be registered when a component mounts ([useEffect](https://reactjs.org/docs/hooks-effect.html) or [componentDidMount](https://reactjs.org/docs/react-component.html#componentdidmount) / [componentWillUnmount](https://reactjs.org/docs/react-component.html#componentwillunmount)) or imperatively when an event happens, as in the following example:
+
+```jsx
+import Router from 'next/router';
+
+useEffect(() => {
+  const handleRouteChange = url => {
+    console.log('App is changing to: ', url);
+  };
+
+  Router.events.on('routeChangeStart', handleRouteChange);
+  return () => {
+    Router.events.off('routeChangeStart', handleRouteChange);
+  };
+}, []);
+```

--- a/docs/api-routes/api-middlewares.md
+++ b/docs/api-routes/api-middlewares.md
@@ -1,0 +1,118 @@
+---
+description: API Routes provide built-in middlewares that parse the incoming request. Learn more about them here.
+---
+
+# API Middlewares
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-middleware">API Routes with middleware</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-cors">API Routes with CORS</a></li>
+  </ul>
+</details>
+
+API routes provide built in middlewares which parse the incoming request (`req`). Those middlewares are:
+
+- `req.cookies` - An object containing the cookies sent by the request. Defaults to `{}`
+- `req.query` - An object containing the [query string](https://en.wikipedia.org/wiki/Query_string). Defaults to `{}`
+- `req.body` - An object containing the body parsed by `content-type`, or `null` if no body was sent
+
+## Custom config
+
+Every API route can export a `config` object to change the default configs, which are the following:
+
+```js
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '1mb'
+    }
+  }
+};
+```
+
+The `api` object includes all configs available for API routes.
+
+`bodyParser` Enables body parsing, you can disable it if you want to consume it as a `Stream`:
+
+```js
+export const config = {
+  api: {
+    bodyParser: false
+  }
+};
+```
+
+`bodyParser.sizeLimit` is the maximum size allowed for the parsed body, in any format supported by [bytes](https://github.com/visionmedia/bytes.js), like so:
+
+```js
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '500kb'
+    }
+  }
+};
+```
+
+`externalResolver` is an explicit flag that tells the server that this route is being handled by an external resolver like _express_ or _connect_. Enabling this option disables warnings for unresolved requests.
+
+```js
+export const config = {
+  api: {
+    externalResolver: true
+  }
+};
+```
+
+## Connect/Express middleware support
+
+You can also use [Connect](https://github.com/senchalabs/connect) compatible middleware.
+
+For example, [configuring CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for your API endpoint can be done leveraging the [cors](https://www.npmjs.com/package/cors) package.
+
+First, install `cors`:
+
+```bash
+npm i cors
+# or
+yarn add cors
+```
+
+Now, let's add `cors` to the API route:
+
+```js
+import Cors from 'cors';
+
+// Initializing the cors middleware
+const cors = Cors({
+  methods: ['GET', 'HEAD']
+});
+
+// Helper method to wait for a middleware to execute before continuing
+// And to throw an error when an error happens in a middleware
+function runMiddleware(req, res, fn) {
+  return new Promise((resolve, reject) => {
+    fn(req, res, result => {
+      if (result instanceof Error) {
+        return reject(result);
+      }
+
+      return resolve(result);
+    });
+  });
+}
+
+async function handler(req, res) {
+  // Run the middleware
+  await runMiddleware(req, res, cors);
+
+  // Rest of the API logic
+  res.json({ message: 'Hello Everyone!' });
+}
+
+export default handler;
+```
+
+> Go to the [API Routes with CORS](https://github.com/zeit/next.js/tree/canary/examples/api-routes-cors) example to see the finished app

--- a/docs/api-routes/dynamic-api-routes.md
+++ b/docs/api-routes/dynamic-api-routes.md
@@ -1,0 +1,113 @@
+---
+description: You can add the dynamic routes used for pages to API Routes too. Learn how it works here.
+---
+
+# Dynamic API Routes
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes">Basic API Routes</a></li>
+  </ul>
+</details>
+
+API routes support [dynamic routes](/docs/routing/dynamic-routes.md), and follow the same file naming rules used for `pages`.
+
+For example, the API route `pages/api/post/[pid].js` has the following code:
+
+```js
+export default (req, res) => {
+  const {
+    query: { pid }
+  } = req;
+
+  res.end(`Post: ${pid}`);
+};
+```
+
+Now, a request to `/api/post/abc` will respond with the text: `Post: abc`.
+
+### Index routes and Dynamic API routes
+
+A very common RESTful pattern is to set up routes like this:
+
+- `GET api/posts/` - gets a list of posts, probably paginated
+- `GET api/posts/12345` - gets post id 12345
+
+We can model this in two ways:
+
+- Option 1:
+  - `/api/posts.js`
+  - `/api/posts/[postId].js`
+- Option 2:
+
+  - `/api/posts/index.js`
+  - `/api/posts/[postId].js`
+
+Both are equivalent. A third option of only using `/api/posts/[postId].js` is not valid because Dynamic Routes (including Catch-all routes - see below) do not have an `undefined` state and `GET api/posts/` will not match `/api/posts/[postId].js` under any circumstances.
+
+### Catch all API routes
+
+API Routes can be extended to catch all paths by adding three dots (`...`) inside the brackets. For example:
+
+- `pages/api/post/[...slug].js` matches `/api/post/a`, but also `/api/post/a/b`, `/api/post/a/b/c` and so on.
+
+> **Note**: You can use names other than `slug`, such as: `[...param]`
+
+Matched parameters will be sent as a query parameter (`slug` in the example) to the page, and it will always be an array, so, the path `/api/post/a` will have the following `query` object:
+
+```json
+{ "slug": ["a"] }
+```
+
+And in the case of `/api/post/a/b`, and any other matching path, new parameters will be added to the array, like so:
+
+```json
+{ "slug": ["a", "b"] }
+```
+
+An API route for `pages/api/post/[...slug].js` could look like this:
+
+```js
+export default (req, res) => {
+  const {
+    query: { slug }
+  } = req;
+
+  res.end(`Post: ${slug.join(', ')}`);
+};
+```
+
+Now, a request to `/api/post/a/b/c` will respond with the text: `Post: a, b, c`.
+
+### Optional catch all API routes
+
+Catch all routes can be made optional by including the parameter in double brackets (`[[...slug]]`).
+
+For example, `pages/api/post/[[...slug]].js` will match `/api/post`, `/api/post/a`, `/api/post/a/b`, and so on.
+
+The `query` objects are as follows:
+
+```json
+{ } // GET `/api/post` (empty object)
+{ "slug": ["a"] } // `GET /api/post/a` (single-element array)
+{ "slug": ["a", "b"] } // `GET /api/post/a/b` (multi-element array)
+```
+
+## Caveats
+
+- Predefined API routes take precedence over dynamic API routes, and dynamic API routes over catch all API routes. Take a look at the following examples:
+  - `pages/api/post/create.js` - Will match `/api/post/create`
+  - `pages/api/post/[pid].js` - Will match `/api/post/1`, `/api/post/abc`, etc. But not `/api/post/create`
+  - `pages/api/post/[...slug].js` - Will match `/api/post/1/2`, `/api/post/a/b/c`, etc. But not `/api/post/create`, `/api/post/abc`
+
+## Related
+
+For more information on what to do next, we recommend the following sections:
+
+<div class="card">
+  <a href="/docs/routing/dynamic-routes.md">
+    <b>Dynamic Routes:</b>
+    <small>Learn more about the built-in dynamic routes.</small>
+  </a>
+</div>

--- a/docs/api-routes/introduction.md
+++ b/docs/api-routes/introduction.md
@@ -1,0 +1,78 @@
+---
+description: Next.js supports API Routes, which allow you to build your API without leaving your Next.js app. Learn how it works here.
+---
+
+# API Routes
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes">Basic API Routes</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-middleware">API Routes with middleware</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-graphql">API Routes with GraphQL</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-rest">API Routes with REST</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-cors">API Routes with CORS</a></li>
+  </ul>
+</details>
+
+API routes provide a straightforward solution to build your **API** with Next.js.
+
+Any file inside the folder `pages/api` is mapped to `/api/*` and will be treated as an API endpoint instead of a `page`.
+
+For example, the following API route `pages/api/user.js` handles a `json` response:
+
+```js
+export default (req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify({ name: 'John Doe' }));
+};
+```
+
+For an API route to work, you need to export as default a function (a.k.a **request handler**), which then receives the following parameters:
+
+- `req`: An instance of [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage), plus some pre-built middlewares you can see [here](/docs/api-routes/api-middlewares.md)
+- `res`: An instance of [http.ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse), plus some helper functions you can see [here](/docs/api-routes/response-helpers.md)
+
+To handle different HTTP methods in an API route, you can use `req.method` in your request handler, like so:
+
+```js
+export default (req, res) => {
+  if (req.method === 'POST') {
+    // Process a POST request
+  } else {
+    // Handle any other HTTP method
+  }
+};
+```
+
+To fetch API endpoints, take a look into any of the examples at the start of this section.
+
+> API Routes [do not specify CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS), meaning they are **same-origin only** by default. You can customize such behavior by wrapping the request handler with the [cors middleware](/docs/api-routes/api-middlewares.md#connectexpress-middleware-support).
+
+> API Routes do not increase your client-side bundle size. They are server-side only bundles.
+
+## Related
+
+For more information on what to do next, we recommend the following sections:
+
+<div class="card">
+  <a href="/docs/api-routes/api-middlewares.md">
+    <b>API Middlewares:</b>
+    <small>learn about the built-in middlewares for the request.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/api-routes/response-helpers.md">
+    <b>Response Helpers:</b>
+    <small>learn about the built-in methods for the response.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/typescript.md#api-routes">
+    <b>TypeScript:</b>
+    <small>Add TypeScript to your API Routes.</small>
+  </a>
+</div>

--- a/docs/api-routes/response-helpers.md
+++ b/docs/api-routes/response-helpers.md
@@ -1,0 +1,27 @@
+---
+description: API Routes include a set of Express.js-like methods for the response to help you creating new API endpoints. Learn how it works here.
+---
+
+# Response Helpers
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes">Basic API Routes</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-rest">API Routes with REST</a></li>
+  </ul>
+</details>
+
+The response (`res`) includes a set of Express.js-like methods to improve the developer experience and increase the speed of creating new API endpoints, take a look at the following example:
+
+```js
+export default (req, res) => {
+  res.status(200).json({ name: 'Next.js' });
+};
+```
+
+The included helpers are:
+
+- `res.status(code)` - A function to set the status code. `code` must be a valid [HTTP status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
+- `res.json(json)` - Sends a JSON response. `json` must be a valid JSON object
+- `res.send(body)` - Sends the HTTP response. `body` can be a `string`, an `object` or a `Buffer`

--- a/docs/basic-features/built-in-css-support.md
+++ b/docs/basic-features/built-in-css-support.md
@@ -1,0 +1,211 @@
+---
+description: Next.js supports including CSS files as Global CSS or CSS Modules, using `styled-jsx` for CSS-in-JS, or any other CSS-in-JS solution! Learn more here.
+---
+
+# Built-In CSS Support
+
+Next.js allows you to import CSS files from a JavaScript file.
+This is possible because Next.js extends the concept of [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) beyond JavaScript.
+
+## Adding a Global Stylesheet
+
+To add a stylesheet to your application, import the CSS file within `pages/_app.js`.
+
+For example, consider the following stylesheet named `styles.css`:
+
+```css
+body {
+  font-family: 'SF Pro Text', 'SF Pro Icons', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+  padding: 20px 20px 60px;
+  max-width: 680px;
+  margin: 0 auto;
+}
+```
+
+Create a [`pages/_app.js` file](/docs/advanced-features/custom-app) if not already present.
+Then, [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) the `styles.css` file.
+
+```jsx
+import '../styles.css';
+
+// This default export is required in a new `pages/_app.js` file.
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+```
+
+These styles (`styles.css`) will apply to all pages and components in your application.
+Due to the global nature of stylesheets, and to avoid conflicts, you may **only import them inside [`pages/_app.js`](/docs/advanced-features/custom-app)**.
+
+In development, expressing stylesheets this way allows your styles to be hot reloaded as you edit them—meaning you can keep application state.
+
+In production, all CSS files will be automatically concatenated into a single minified `.css` file.
+
+## Adding Component-Level CSS
+
+Next.js supports [CSS Modules](https://github.com/css-modules/css-modules) using the `[name].module.css` file naming convention.
+
+CSS Modules locally scope CSS by automatically creating a unique class name.
+This allows you to use the same CSS class name in different files without worrying about collisions.
+
+This behavior makes CSS Modules the ideal way to include component-level CSS.
+CSS Module files **can be imported anywhere in your application**.
+
+For example, consider a reusable `Button` component in the `components/` folder:
+
+First, create `components/Button.module.css` with the following content:
+
+```css
+/*
+You do not need to worry about .error {} colliding with any other `.css` or
+`.module.css` files!
+*/
+.error {
+  color: white;
+  background-color: red;
+}
+```
+
+Then, create `components/Button.js`, importing and using the above CSS file:
+
+```jsx
+import styles from './Button.module.css';
+
+export function Button() {
+  return (
+    <button
+      type="button"
+      // Note how the "error" class is accessed as a property on the imported
+      // `styles` object.
+      className={styles.error}
+    >
+      Destroy
+    </button>
+  );
+}
+```
+
+CSS Modules are an _optional feature_ and are **only enabled for files with the `.module.css` extension**.
+Regular `<link>` stylesheets and global CSS files are still supported.
+
+In production, all CSS Module files will be automatically concatenated into **many minified and code-split** `.css` files.
+These `.css` files represent hot execution paths in your application, ensuring the minimal amount of CSS is loaded for your application to paint.
+
+## Sass Support
+
+Next.js allows you to import Sass using both the `.scss` and `.sass` extensions.
+You can use component-level Sass via CSS Modules and the `.module.scss` or `.module.sass` extension.
+
+Before you can use Next.js' built-in Sass support, be sure to install [`sass`](https://github.com/sass/sass):
+
+```bash
+npm install sass
+```
+
+Sass support has the same benefits and restrictions as the built-in CSS support detailed above.
+
+### Customizing Sass Options
+
+If you want to configure the Sass compiler you can do so by using `sassOptions` in `next.config.js`.
+
+For example to add `includePaths`:
+
+```js
+const path = require('path');
+
+module.exports = {
+  sassOptions: {
+    includePaths: [path.join(__dirname, 'styles')]
+  }
+};
+```
+
+## Less and Stylus Support
+
+To support importing `.less` or `.styl` files you can use the following plugins:
+
+- [@zeit/next-less](https://github.com/zeit/next-plugins/tree/master/packages/next-less)
+- [@zeit/next-stylus](https://github.com/zeit/next-plugins/tree/master/packages/next-stylus)
+
+If using the less plugin, don't forget to add a dependency on less as well, otherwise you'll see an error like:
+
+```bash
+Error: Cannot find module 'less'
+```
+
+## CSS-in-JS
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/basic-css">Styled JSX</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-styled-components">Styled Components</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-styletron">Styletron</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-glamor">Glamor</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-cxs">Cxs</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-aphrodite">Aphrodite</a></li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-fela">Fela</a></li>
+  </ul>
+</details>
+
+It's possible to use any existing CSS-in-JS solution.
+The simplest one is inline styles:
+
+```jsx
+function HiThere() {
+  return <p style={{ color: 'red' }}>hi there</p>;
+}
+
+export default HiThere;
+```
+
+We bundle [styled-jsx](https://github.com/zeit/styled-jsx) to provide support for isolated scoped CSS.
+The aim is to support "shadow CSS" similar to Web Components, which unfortunately [do not support server-rendering and are JS-only](https://github.com/w3c/webcomponents/issues/71).
+
+See the above examples for other popular CSS-in-JS solutions (like Styled Components).
+
+A component using `styled-jsx` looks like this:
+
+```jsx
+function HelloWorld() {
+  return (
+    <div>
+      Hello world
+      <p>scoped!</p>
+      <style jsx>{`
+        p {
+          color: blue;
+        }
+        div {
+          background: red;
+        }
+        @media (max-width: 600px) {
+          div {
+            background: blue;
+          }
+        }
+      `}</style>
+      <style global jsx>{`
+        body {
+          background: black;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default HelloWorld;
+```
+
+Please see the [styled-jsx documentation](https://github.com/zeit/styled-jsx) for more examples.
+
+## Related
+
+For more information on what to do next, we recommend the following sections:
+
+<div class="card">
+  <a href="/docs/advanced-features/customizing-postcss-config.md">
+    <b>Customizing PostCSS Config:</b>
+    <small>Extend the PostCSS config and plugins added by Next.js with your own.</small>
+  </a>
+</div>

--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -1,0 +1,518 @@
+---
+description: 'Next.js has 2 pre-rendering modes: Static Generation and Server-side rendering. Learn how they work here.'
+---
+
+# Data fetching
+
+> This document is for Next.js versions 9.3 and up. If you’re using older versions of Next.js, refer to our [previous documentation](https://nextjs.org/docs/tag/v9.2.2/basic-features/data-fetching).
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/blog-starter">Blog Starter using markdown files</a> (<a href="https://next-blog-starter.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-datocms">DatoCMS Example</a> (<a href="https://next-blog-datocms.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-takeshape">TakeShape Example</a> (<a href="https://next-blog-takeshape.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-sanity">Sanity Example</a> (<a href="https://next-blog-sanity.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-prismic">Prismic Example</a> (<a href="https://next-blog-prismic.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-contentful">Contentful Example</a> (<a href="https://next-blog-contentful.now.sh/">Demo</a>)</li>
+    <li><a href="https://static-tweet.now.sh/">Static Tweet Demo</a></li>
+  </ul>
+</details>
+
+In the [Pages documentation](/docs/basic-features/pages.md), we’ve explained that Next.js has two forms of pre-rendering: **Static Generation** and **Server-side Rendering**. In this page, we’ll talk in depths about data fetching strategies for each case. We recommend you to [read through the Pages documentation](/docs/basic-features/pages.md) first if you haven’t done so.
+
+We’ll talk about the three unique Next.js functions you can use to fetch data for pre-rendering:
+
+- [`getStaticProps`](#getstaticprops-static-generation) (Static Generation): Fetch data at **build time**.
+- [`getStaticPaths`](#getstaticpaths-static-generation) (Static Generation): Specify [dynamic routes](/docs/routing/dynamic-routes.md) to pre-render based on data.
+- [`getServerSideProps`](#getserversideprops-server-side-rendering) (Server-side Rendering): Fetch data on **each request**.
+
+In addition, we’ll talk briefly about how to do fetch data on the client side.
+
+## `getStaticProps` (Static Generation)
+
+If you export an `async` function called `getStaticProps` from a page, Next.js will pre-render this page at build time using the props returned by `getStaticProps`.
+
+```jsx
+export async function getStaticProps(context) {
+  return {
+    props: {} // will be passed to the page component as props
+  };
+}
+```
+
+The `context` parameter is an object containing the following keys:
+
+- `params` contains the route parameters for pages using dynamic routes. For example, if the page name is `[id].js` , then `params` will look like `{ id: ... }`. To learn more, take a look at the [Dynamic Routing documentation](/docs/routing/dynamic-routes.md). You should use this together with `getStaticPaths`, which we’ll explain later.
+- `preview` is `true` if the page is in the preview mode and `false` otherwise. See the [Preview Mode documentation](/docs/advanced-features/preview-mode.md).
+- `previewData` contains the preview data set by `setPreviewData`. See the [Preview Mode documentation](/docs/advanced-features/preview-mode.md).
+
+### Simple Example
+
+Here’s an example which uses `getStaticProps` to fetch a list of blog posts from a CMS (content management system). This example is also in the [Pages documentation](/docs/basic-features/pages.md).
+
+```jsx
+// posts will be populated at build time by getStaticProps()
+function Blog({ posts }) {
+  return (
+    <ul>
+      {posts.map(post => (
+        <li>{post.title}</li>
+      ))}
+    </ul>
+  );
+}
+
+// This function gets called at build time on server-side.
+// It won't be called on client-side, so you can even do
+// direct database queries. See the "Technical details" section.
+export async function getStaticProps() {
+  // Call an external API endpoint to get posts.
+  // You can use any data fetching library
+  const res = await fetch('https://.../posts');
+  const posts = await res.json();
+
+  // By returning { props: posts }, the Blog component
+  // will receive `posts` as a prop at build time
+  return {
+    props: {
+      posts
+    }
+  };
+}
+
+export default Blog;
+```
+
+### When should I use `getStaticProps`?
+
+You should use `getStaticProps` if:
+
+- The data required to render the page is available at build time ahead of a user’s request.
+- The data comes from headless CMS.
+- The data can be publicly cached (not user-specific).
+- The page must be pre-rendered (for SEO) and be very fast — `getStaticProps` generates HTML and JSON files, both of which can be cached by a CDN for performance.
+
+### TypeScript: Use `GetStaticProps`
+
+For TypeScript, you can use the `GetStaticProps` type from `next`:
+
+```ts
+import { GetStaticProps } from 'next';
+
+export const getStaticProps: GetStaticProps = async context => {
+  // ...
+};
+```
+
+### Reading files: Use `process.cwd()`
+
+Files can be read directly from the filesystem in `getStaticProps`.
+
+In order to do so you have to get the full path to a file.
+
+Since Next.js compiles your code into a separate directory you can't use `__dirname` as the path it will return will be different from the pages directory.
+
+Instead you can use `process.cwd()` which gives you the directory where Next.js is being executed.
+
+```jsx
+import fs from 'fs';
+import path from 'path';
+
+// posts will be populated at build time by getStaticProps()
+function Blog({ posts }) {
+  return (
+    <ul>
+      {posts.map(post => (
+        <li>
+          <h3>{post.filename}</h3>
+          <p>{post.content}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// This function gets called at build time on server-side.
+// It won't be called on client-side, so you can even do
+// direct database queries. See the "Technical details" section.
+export async function getStaticProps() {
+  const postsDirectory = path.join(process.cwd(), 'posts');
+  const filenames = fs.readdirSync(postsDirectory);
+
+  const posts = filenames.map(filename => {
+    const filePath = path.join(postsDirectory, filename);
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+
+    // Generally you would parse/transform the contents
+    // For example you can transform markdown to HTML here
+
+    return {
+      filename,
+      content: fileContents
+    };
+  });
+  // By returning { props: posts }, the Blog component
+  // will receive `posts` as a prop at build time
+  return {
+    props: {
+      posts
+    }
+  };
+}
+
+export default Blog;
+```
+
+### Technical details
+
+#### Only runs at build time
+
+Because `getStaticProps` runs at build time, it does **not** receive data that’s only available during request time, such as query parameters or HTTP headers as it generates static HTML.
+
+#### Write server-side code directly
+
+Note that `getStaticProps` runs only on the server-side. It will never be run on the client-side. It won’t even be included in the JS bundle for the browser. That means you can write code such as direct database queries without them being sent to browsers. You should not fetch an **API route** from `getStaticProps` — instead, you can write the server-side code directly in `getStaticProps`.
+
+#### Statically Generates both HTML and JSON
+
+When a page with `getStaticProps` is pre-rendered at build time, in addition to the page HTML file, Next.js generates a JSON file holding the result of running `getStaticProps`.
+
+This JSON file will be used in client-side routing through `next/link` ([documentation](/docs/api-reference/next/link.md)) or `next/router` ([documentation](/docs/api-reference/next/router.md)). When you navigate to a page that’s pre-rendered using `getStaticProps`, Next.js fetches this JSON file (pre-computed at build time) and uses it as the props for the page component. This means that client-side page transitions will **not** call `getStaticProps` as only the exported JSON is used.
+
+#### Only allowed in a page
+
+`getStaticProps` can only be exported from a **page**. You can’t export it from non-page files.
+
+One of the reasons for this restriction is that React needs to have all the required data before the page is rendered.
+
+Also, you must use `export async function getStaticProps() {}` — it will **not** work if you add `getStaticProps` as a property of the page component.
+
+#### Runs on every request in development
+
+In development (`next dev`), `getStaticProps` will be called on every request.
+
+#### Preview Mode
+
+In some cases, you might want to temporarily bypass Static Generation and render the page at **request time** instead of build time. For example, you might be using a headless CMS and want to preview drafts before they're published.
+
+This use case is supported by Next.js by the feature called **Preview Mode**. Learn more on the [Preview Mode documentation](/docs/advanced-features/preview-mode.md).
+
+## `getStaticPaths` (Static Generation)
+
+If a page has dynamic routes ([documentation](/docs/routing/dynamic-routes.md)) and uses `getStaticProps` it needs to define a list of paths that have to be rendered to HTML at build time.
+
+If you export an `async` function called `getStaticPaths` from a page that uses dynamic routes, Next.js will statically pre-render all the paths specified by `getStaticPaths`.
+
+```jsx
+export async function getStaticPaths() {
+  return {
+    paths: [
+      { params: { ... } } // See the "paths" section below
+    ],
+    fallback: true or false // See the "fallback" section below
+  };
+}
+```
+
+#### The `paths` key (required)
+
+The `paths` key determines which paths will be pre-rendered. For example, suppose that you have a page that uses dynamic routes named `pages/posts/[id].js`. If you export `getStaticPaths` from this page and return the following for `paths`:
+
+```js
+return {
+  paths: [
+    { params: { id: '1' } },
+    { params: { id: '2' } }
+  ],
+  fallback: ...
+}
+```
+
+Then Next.js will statically generate `posts/1` and `posts/2` at build time using the page component in `pages/posts/[id].js`.
+
+Note that the value for each `params` must match the parameters used in the page name:
+
+- If the page name is `pages/posts/[postId]/[commentId]`, then `params` should contain `postId` and `commentId`.
+- If the page name uses catch-all routes, for example `pages/[...slug]`, then `params` should contain `slug` which is an array. For example, if this array is `['foo', 'bar']`, then Next.js will statically generate the page at `/foo/bar`.
+
+#### The `fallback` key (required)
+
+The object returned by `getStaticPaths` must contain a boolean `fallback` key.
+
+#### `fallback: false`
+
+If `fallback` is `false`, then any paths not returned by `getStaticPaths` will result in a **404 page**. You can do this if you have a small number of paths to pre-render - so they are all statically generated during build time. It’s also useful when the new pages are not added often. If you add more items to the data source and need to render the new pages, you’d need to run the build again.
+
+Here’s an example which pre-renders one blog post per page called `pages/posts/[id].js`. The list of blog posts will be fetched from a CMS and returned by `getStaticPaths` . Then, for each page, it fetches the post data from a CMS using `getStaticProps`. This example is also in the [Pages documentation](/docs/basic-features/pages.md).
+
+```jsx
+// pages/posts/[id].js
+
+function Post({ post }) {
+  // Render post...
+}
+
+// This function gets called at build time
+export async function getStaticPaths() {
+  // Call an external API endpoint to get posts
+  const res = await fetch('https://.../posts');
+  const posts = await res.json();
+
+  // Get the paths we want to pre-render based on posts
+  const paths = posts.map(post => ({
+    params: { id: post.id }
+  }));
+
+  // We'll pre-render only these paths at build time.
+  // { fallback: false } means other routes should 404.
+  return { paths, fallback: false };
+}
+
+// This also gets called at build time
+export async function getStaticProps({ params }) {
+  // params contains the post `id`.
+  // If the route is like /posts/1, then params.id is 1
+  const res = await fetch(`https://.../posts/${params.id}`);
+  const post = await res.json();
+
+  // Pass post data to the page via props
+  return { props: { post } };
+}
+
+export default Post;
+```
+
+#### `fallback: true`
+
+If `fallback` is `true`, then the behavior of `getStaticProps` changes:
+
+- The paths returned from `getStaticPaths` will be rendered to HTML at build time.
+- The paths that have not been generated at build time will **not** result in a 404 page. Instead, Next.js will serve a “fallback” version of the page on the first request to such a path (see [“Fallback pages”](#fallback-pages) below for details).
+- In the background, Next.js will statically generate the requested path HTML and JSON. This includes running `getStaticProps`.
+- When that’s done, the browser receives the JSON for the generated path. This will be used to automatically render the page with the required props. From the user’s perspective, the page will be swapped from the fallback page to the full page.
+- At the same time, Next.js adds this path to the list of pre-rendered pages. Subsequent requests to the same path will serve the generated page, just like other pages pre-rendered at build time.
+
+#### Fallback pages
+
+In the “fallback” version of a page:
+
+- The page’s props will be empty.
+- Using the [router](/docs/api-reference/next/router.md), you can detect if the fallback is being rendered, `router.isFallback` will be `true`.
+
+Here’s an example that uses `isFallback`:
+
+```jsx
+// pages/posts/[id].js
+import { useRouter } from 'next/router';
+
+function Post({ post }) {
+  const router = useRouter();
+
+  // If the page is not yet generated, this will be displayed
+  // initially until getStaticProps() finishes running
+  if (router.isFallback) {
+    return <div>Loading...</div>;
+  }
+
+  // Render post...
+}
+
+// This function gets called at build time
+export async function getStaticPaths() {
+  return {
+    // Only `/posts/1` and `/posts/2` are generated at build time
+    paths: [{ params: { id: '1' } }, { params: { id: '2' } }],
+    // Enable statically generating additional pages
+    // For example: `/posts/3`
+    fallback: true
+  };
+}
+
+// This also gets called at build time
+export async function getStaticProps({ params }) {
+  // params contains the post `id`.
+  // If the route is like /posts/1, then params.id is 1
+  const res = await fetch(`https://.../posts/${params.id}`);
+  const post = await res.json();
+
+  // Pass post data to the page via props
+  return { props: { post } };
+}
+
+export default Post;
+```
+
+#### When is `fallback: true` useful?
+
+`fallback: true` is useful if your app has a very large number of static pages that depend on data (think: a very large e-commerce site). You want to pre-render all product pages, but then your builds would take forever.
+
+Instead, you may statically generate a small subset of pages and use `fallback: true` for the rest. When someone requests a page that’s not generated yet, the user will see the page with a loading indicator. Shortly after, `getStaticProps` finishes and the page will be rendered with the requested data. From now on, everyone who requests the same page will get the statically pre-rendered page.
+
+This ensures that users always have a fast experience while preserving fast builds and the benefits of Static Generation.
+
+### When should I use `getStaticPaths`?
+
+You should use `getStaticPaths` if you’re statically pre-rendering pages that use dynamic routes.
+
+### TypeScript: Use `GetStaticPaths`
+
+For TypeScript, you can use the `GetStaticPaths` type from `next`:
+
+```ts
+import { GetStaticPaths } from 'next';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // ...
+};
+```
+
+### Technical details
+
+#### Use together with `getStaticProps`
+
+When you use `getStaticProps` on a page with dynamic route parameters, you must use `getStaticPaths`.
+
+You cannot use `getStaticPaths` with `getServerSideProps`.
+
+#### Only runs at build time on server-side
+
+`getStaticPaths` only runs at build time on server-side.
+
+#### Only allowed in a page
+
+`getStaticPaths` can only be exported from a **page**. You can’t export it from non-page files.
+
+Also, you must use `export async function getStaticPaths() {}` — it will **not** work if you add `getStaticPaths` as a property of the page component.
+
+#### Runs on every request in development
+
+In development (`next dev`), `getStaticPaths` will be called on every request.
+
+## `getServerSideProps` (Server-side Rendering)
+
+If you export an `async` function called `getServerSideProps` from a page, Next.js will pre-render this page on each request using the data returned by `getServerSideProps`.
+
+```js
+export async function getServerSideProps(context) {
+  return {
+    props: {} // will be passed to the page component as props
+  };
+}
+```
+
+The `context` parameter is an object containing the following keys:
+
+- `params`: If this page uses a dynamic route, `params` contains the route parameters. If the page name is `[id].js` , then `params` will look like `{ id: ... }`. To learn more, take a look at the [Dynamic Routing documentation](/docs/routing/dynamic-routes.md).
+- `req`: [The HTTP IncomingMessage object](https://nodejs.org/api/http.html#http_class_http_incomingmessage).
+- `res`: [The HTTP response object](https://nodejs.org/api/http.html#http_class_http_serverresponse).
+- `query`: The query string.
+- `preview`: `preview` is `true` if the page is in the preview mode and `false` otherwise. See the [Preview Mode documentation](/docs/advanced-features/preview-mode.md).
+- `previewData`: The preview data set by `setPreviewData`. See the [Preview Mode documentation](/docs/advanced-features/preview-mode.md).
+
+### Simple example
+
+Here’s an example which uses `getServerSideProps` to fetch data at request time and pre-renders it. This example is also in the [Pages documentation](/docs/basic-features/pages.md).
+
+```jsx
+function Page({ data }) {
+  // Render data...
+}
+
+// This gets called on every request
+export async function getServerSideProps() {
+  // Fetch data from external API
+  const res = await fetch(`https://.../data`);
+  const data = await res.json();
+
+  // Pass data to the page via props
+  return { props: { data } };
+}
+
+export default Page;
+```
+
+### When should I use `getServerSideProps`?
+
+You should use `getServerSideProps` only if you need to pre-render a page whose data must be fetched at request time. Time to first byte (TTFB) will be slower than `getStaticProps` because the server must compute the result on every request, and the result cannot be cached by a CDN without extra configuration.
+
+If you don’t need to pre-render the data, then you should consider fetching data on the client side. [Click here to learn more](#fetching-data-on-the-client-side).
+
+### TypeScript: Use `GetServerSideProps`
+
+For TypeScript, you can use the `GetServerSideProps` type from `next`:
+
+```ts
+import { GetServerSideProps } from 'next';
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  // ...
+};
+```
+
+### Technical details
+
+#### Only runs on server-side
+
+`getServerSideProps` only runs on server-side and never runs on the browser. If a page uses `getServerSideProps` , then:
+
+- When you request this page directly, `getServerSideProps` runs at the request time, and this page will be pre-rendered with the returned props.
+- When you request this page on client-side page transitions through `next/link` ([documentation](/docs/api-reference/next/link.md)) or `next/router` ([documentation](/docs/api-reference/next/router.md)), Next.js sends an API request to the server, which runs `getServerSideProps`. It’ll return JSON that contains the result of running `getServerSideProps`, and the JSON will be used to render the page. All this work will be handled automatically by Next.js, so you don’t need to do anything extra as long as you have `getServerSideProps` defined.
+
+#### Only allowed in a page
+
+`getServerSideProps` can only be exported from a **page**. You can’t export it from non-page files.
+
+Also, you must use `export async function getServerSideProps() {}` — it will **not** work if you add `getServerSideProps` as a property of the page component.
+
+## Fetching data on the client side
+
+If your page contains frequently updating data, and you don’t need to pre-render the data, you can fetch the data on the client side. An example of this is user-specific data. Here’s how it works:
+
+- First, immediately show the page without data. Parts of the page can be pre-rendered using Static Generation. You can show loading states for missing data.
+- Then, fetch the data on the client side and display it when ready.
+
+This approach works well for user dashboard pages, for example. Because a dashboard is a private, user-specific page, SEO is not relevant and the page doesn’t need to be pre-rendered. The data is frequently updated, which requires request-time data fetching.
+
+### SWR
+
+The team behind Next.js has created a React hook for data fetching called [**SWR**](https://swr.now.sh/). We highly recommend it if you’re fetching data on the client side. It handles caching, revalidation, focus tracking, refetching on interval, and more. And you can use it like so:
+
+```jsx
+import useSWR from 'swr';
+
+function Profile() {
+  const { data, error } = useSWR('/api/user', fetch);
+
+  if (error) return <div>failed to load</div>;
+  if (!data) return <div>loading...</div>;
+  return <div>hello {data.name}!</div>;
+}
+```
+
+[Check out the SWR documentation to learn more](https://swr.now.sh/).
+
+## Learn more
+
+We recommend you to read the following sections next:
+
+<div class="card">
+  <a href="/docs/advanced-features/preview-mode.md">
+    <b>Preview Mode:</b>
+    <small>Learn more about the preview mode in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/routing/introduction.md">
+    <b>Routing:</b>
+    <small>Learn more about routing in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/typescript.md#pages">
+    <b>TypeScript:</b>
+    <small>Add TypeScript to your pages.</small>
+  </a>
+</div>

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -1,0 +1,107 @@
+---
+description: Learn to add and access environment variables in your Next.js application.
+---
+
+# Environment Variables
+
+> This document is for Next.js versions 9.4 and up. If you’re using an older version of Next.js, refer to [Environment Variables in next.config.js](/docs/api-reference/next.config.js/environment-variables.md).
+
+Next.js comes with built-in support for environment variables, which allows you to do the following:
+
+- [Inline variables starting with `NEXT_PUBLIC_`](#inlined-environment-variables)
+- [Use `.env` to add custom environment variables](#exposing-environment-variables)
+
+## Inlined Environment Variables
+
+Next.js will inline any environment variable that starts with `NEXT_PUBLIC_` in your application. Inlining means replacing the variable with the value. For example, the following page:
+
+```jsx
+export default function Page() {
+  return <h1>The public value is: {process.env.NEXT_PUBLIC_EXAMPLE_KEY}</h1>;
+}
+```
+
+Will end up being:
+
+```jsx
+export default function Page() {
+  return <h1>The public value is: {'my-value'}</h1>;
+}
+```
+
+Next.js replaced `process.env.NEXT_PUBLIC_EXAMPLE_KEY` with its value, that in this case is `'my-value'`.
+
+You can use the shell or any other tool that runs before the [Next.js CLI](/api-reference/cli) to add environment variables. For example, using bash:
+
+```bash
+NEXT_PUBLIC_EXAMPLE_KEY=my-value npx next dev
+```
+
+Or using [cross-env](https://github.com/kentcdodds/cross-env) for Windows and Unix support:
+
+```bash
+npx cross-env NEXT_PUBLIC_EXAMPLE_KEY=my-value next dev
+```
+
+### Caveats
+
+- Trying to destructure `process.env` variables won't work due to the limitations of webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/).
+- To avoid exposing secrets, do not use the `NEXT_PUBLIC_` prefix for them. Instead, [expose the variables using `.env`](#exposing-environment-variables).
+
+## Exposing Environment Variables
+
+Next.js allows you to expose variables using an environment variables file (`.env`), with included support for multiple environments. It works like this:
+
+- `.env` - Contains environment variables for all environments
+- `.env.local` - Local variable overrides for all environments
+- `.env.[environment]` - Environment variables for one environment. For example: `.env.development`
+- `.env.[environment].local` - Local variable overrides for one environment. For example: `.env.development.local`
+
+> **Note**: `.env` files **should be** included in your repository, and **`.env*.local` should be in `.gitignore`**, as those files are intended to be ignored. Consider `.local` files as a good place for secrets, and non-local files as a good place for defaults.
+
+The supported environments are `development`, `production` and `test`. The environment is selected in the following way:
+
+- [`next dev`](/docs/api-reference/cli#development) uses `development`
+- [`next build`](/docs/api-reference/cli#build) and [`next start`](/docs/api-reference/cli#production) use `production`
+
+If the same environment variable is defined multiple times, the priority of which variable to use is decided in the following order:
+
+- Already defined environment variables have the higher priority. For example: `MY_KEY=value next dev`
+- `.env.[environment].local`
+- `.env.local`
+- `.env.[environment]`
+- `.env`
+
+For example, consider the file `.env.local` with the following content:
+
+```bash
+API_KEY='my-secret-api-key'
+NEXT_PUBLIC_APP_LOCALE='en-us'
+```
+
+And the following page:
+
+```jsx
+export default function Page() {
+  return <h1>The locale is set to: {process.env.NEXT_PUBLIC_APP_LOCALE}</h1>;
+}
+
+export async function getStaticProps() {
+  const db = await myDB(process.env.API_KEY);
+  // ...
+}
+```
+
+`process.env.NEXT_PUBLIC_APP_LOCALE` will be replaced with `'en-us'` in the build output. This is because variables that start with `NEXT_PUBLIC_` will be [inlined at build time](#inlined-environment-variables).
+
+`process.env.API_KEY` will be a variable with `'my-secret-api-key'` at build time and runtime, but the build output will not contain this key. This is because `process.env.API_KEY` is only used by [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation) which [runs only on the server](/docs/basic-features/data-fetching.md#write-server-side-code-directly) — and only the props returned by `getStaticProps` are included in the client build. Same goes for our other [data fetching methods](/docs/basic-features/data-fetching.md).
+
+Now, if you add a `.env` file like this one:
+
+```bash
+API_KEY='default-api-key'
+CLIENT_KEY='default-client-key'
+NEXT_PUBLIC_APP_LOCALE='en-us'
+```
+
+Both `API_KEY` and `NEXT_PUBLIC_APP_LOCALE` will be ignored as `.env.local` has a higher priority, but `CLIENT_KEY` will become available.

--- a/docs/basic-features/pages.md
+++ b/docs/basic-features/pages.md
@@ -1,0 +1,279 @@
+---
+description: Next.js pages are React Components exported in a file in the pages directory. Learn how they work here.
+---
+
+# Pages
+
+> This document is for Next.js versions 9.3 and up. If you're using older versions of Next.js, refer to our [previous documentation](https://nextjs.org/docs/tag/v9.2.2/basic-features/pages).
+
+In Next.js, a **page** is a [React Component](https://reactjs.org/docs/components-and-props.html) exported from a `.js`, `jsx`, `.ts`, or `.tsx` file in the `pages` directory. Each page is associated with a route based on its file name.
+
+**Example**: If you create `pages/about.js` that exports a React component like below, it will be accessible at `/about`.
+
+```jsx
+function About() {
+  return <div>About</div>;
+}
+
+export default About;
+```
+
+### Pages with Dynamic Routes
+
+Next.js supports pages with dynamic routes. For example, if you create a file called `pages/posts/[id].js`, then it will be accessible at `posts/1`, `posts/2`, etc.
+
+> To learn more about dynamic routing, check the [Dynamic Routing documentation](/docs/routing/dynamic-routes.md).
+
+## Pre-rendering
+
+By default, Next.js **pre-renders** every page. This means that Next.js generates HTML for each page in advance, instead of having it all done by client-side JavaScript. Pre-rendering can result in better performance and SEO.
+
+Each generated HTML is associated with minimal JavaScript code necessary for that page. When a page is loaded by the browser, its JavaScript code runs and makes the page fully interactive. (This process is called _hydration_.)
+
+### Two forms of Pre-rendering
+
+Next.js has two forms of pre-rendering: **Static Generation** and **Server-side Rendering**. The difference is in **when** it generates the HTML for a page.
+
+- [**Static Generation (Recommended)**](#static-generation-recommended): The HTML is generated at **build time** and will be reused on each request.
+- [**Server-side Rendering**](#server-side-rendering): The HTML is generated on **each request**.
+
+Importantly, Next.js lets you **choose** which pre-rendering form you'd like to use for each page. You can create a "hybrid" Next.js app by using Static Generation for most pages and using Server-side Rendering for others.
+
+We **recommend** using **Static Generation** over Server-side Rendering for performance reasons. Statically generated pages can be cached by CDN to boost performance. However, in some cases, Server-side Rendering might be the only option.
+
+Finally, you can always use **Client-side Rendering** along with Static Generation or Server-side Rendering. That means some parts of a page can be rendered entirely by client side JavaScript. To learn more, take a look at the [Data Fetching](/docs/basic-features/data-fetching.md#fetching-data-on-the-client-side) documentation.
+
+## Static Generation (Recommended)
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/blog-starter">Blog Starter using markdown files</a> (<a href="https://next-blog-starter.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-datocms">DatoCMS Example</a> (<a href="https://next-blog-datocms.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-takeshape">TakeShape Example</a> (<a href="https://next-blog-takeshape.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-sanity">Sanity Example</a> (<a href="https://next-blog-sanity.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-prismic">Prismic Example</a> (<a href="https://next-blog-prismic.now.sh/">Demo</a>)</li>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/cms-contentful">Contentful Example</a> (<a href="https://next-blog-contentful.now.sh/">Demo</a>)</li>
+    <li><a href="https://static-tweet.now.sh/">Static Tweet Demo</a></li>
+  </ul>
+</details>
+
+If a page uses **Static Generation**, the page HTML is generated at **build time**. That means in production, the page HTML is generated when you run `next build` . This HTML will then be reused on each request. It can be cached by a CDN.
+
+In Next.js, you can statically generate pages **with or without data**. Let's take a look at each case.
+
+### Static Generation without data
+
+By default, Next.js pre-renders pages using Static Generation without fetching data. Here's an example:
+
+```jsx
+function About() {
+  return <div>About</div>;
+}
+
+export default About;
+```
+
+Note that this page does not need to fetch any external data to be pre-rendered. In cases like this, Next.js generates a single HTML file per page during build time.
+
+### Static Generation with data
+
+Some pages require fetching external data for pre-rendering. There are two scenarios, and one or both might apply. In each case, you can use a special function Next.js provides:
+
+1. Your page **content** depends on external data: Use `getStaticProps`.
+2. Your page **paths** depend on external data: Use `getStaticPaths` (usually in addition to `getStaticProps`).
+
+#### Scenario 1: Your page **content** depends on external data
+
+**Example**: Your blog page might need to fetch the list of blog posts from a CMS (content management system).
+
+```jsx
+// TODO: Need to fetch `posts` (by calling some API endpoint)
+//       before this page can be pre-rendered.
+function Blog({ posts }) {
+  return (
+    <ul>
+      {posts.map(post => (
+        <li>{post.title}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default Blog;
+```
+
+To fetch this data on pre-render, Next.js allows you to `export` an `async` function called `getStaticProps` from the same file. This function gets called at build time and lets you pass fetched data to the page's `props` on pre-render.
+
+```jsx
+function Blog({ posts }) {
+  // Render posts...
+}
+
+// This function gets called at build time
+export async function getStaticProps() {
+  // Call an external API endpoint to get posts
+  const res = await fetch('https://.../posts');
+  const posts = await res.json();
+
+  // By returning { props: posts }, the Blog component
+  // will receive `posts` as a prop at build time
+  return {
+    props: {
+      posts
+    }
+  };
+}
+
+export default Blog;
+```
+
+To learn more about how `getStaticProps` works, check out the [Data Fetching documentation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation).
+
+#### Scenario 2: Your page paths depend on external data
+
+Next.js allows you to create pages with **dynamic routes**. For example, you can create a file called `pages/posts/[id].js` to show a single blog post based on `id`. This will allow you to show a blog post with `id: 1` when you access `posts/1`.
+
+> To learn more about dynamic routing, check the [Dynamic Routing documentation](/docs/routing/dynamic-routes.md).
+
+However, which `id` you want to pre-render at build time might depend on external data.
+
+**Example**: suppose that you've only added one blog post (with `id: 1`) to the database. In this case, you'd only want to pre-render `posts/1` at build time.
+
+Later, you might add the second post with `id: 2`. Then you'd want to pre-render `posts/2` as well.
+
+So your page **paths** that are pre-rendered depend on external data**.** To handle this, Next.js lets you `export` an `async` function called `getStaticPaths` from a dynamic page (`pages/posts/[id].js` in this case). This function gets called at build time and lets you specify which paths you want to pre-render.
+
+```jsx
+// This function gets called at build time
+export async function getStaticPaths() {
+  // Call an external API endpoint to get posts
+  const res = await fetch('https://.../posts');
+  const posts = await res.json();
+
+  // Get the paths we want to pre-render based on posts
+  const paths = posts.map(post => `/posts/${post.id}`);
+
+  // We'll pre-render only these paths at build time.
+  // { fallback: false } means other routes should 404.
+  return { paths, fallback: false };
+}
+```
+
+Also in `pages/posts/[id].js`, you need to export `getStaticProps` so that you can fetch the data about the post with this `id` and use it to pre-render the page:
+
+```jsx
+function Post({ post }) {
+  // Render post...
+}
+
+export async function getStaticPaths() {
+  // ...
+}
+
+// This also gets called at build time
+export async function getStaticProps({ params }) {
+  // params contains the post `id`.
+  // If the route is like /posts/1, then params.id is 1
+  const res = await fetch(`https://.../posts/${params.id}`);
+  const post = await res.json();
+
+  // Pass post data to the page via props
+  return { props: { post } };
+}
+
+export default Post;
+```
+
+To learn more about how `getStaticPaths` works, check out the [Data Fetching documentation](/docs/basic-features/data-fetching.md#getstaticpaths-static-generation).
+
+### When should I use Static Generation?
+
+We recommend using **Static Generation** (with and without data) whenever possible because your page can be built once and served by CDN, which makes it much faster than having a server render the page on every request.
+
+You can use Static Generation for many types of pages, including:
+
+- Marketing pages
+- Blog posts
+- E-commerce product listings
+- Help and documentation
+
+You should ask yourself: "Can I pre-render this page **ahead** of a user's request?" If the answer is yes, then you should choose Static Generation.
+
+On the other hand, Static Generation is **not** a good idea if you cannot pre-render a page ahead of a user's request. Maybe your page shows frequently updated data, and the page content changes on every request.
+
+In cases like this, you can do one of the following:
+
+- Use Static Generation with **Client-side Rendering:** You can skip pre-rendering some parts of a page and then use client-side JavaScript to populate them. To learn more about this approach, check out the [Data Fetching documentation](/docs/basic-features/data-fetching.md#fetching-data-on-the-client-side).
+- Use **Server-Side Rendering:** Next.js pre-renders a page on each request. It will be slower because the page cannot be cached by a CDN, but the pre-rendered page will always be up-to-date. We'll talk about this approach below.
+
+## Server-side Rendering
+
+> Also referred to as "SSR" or "Dynamic Rendering".
+
+If a page uses **Server-side Rendering**, the page HTML is generated on **each request**.
+
+To use Server-side Rendering for a page, you need to `export` an `async` function called `getServerSideProps`. This function will be called by the server on every request.
+
+For example, suppose that your page needs to pre-render frequently updated data (fetched from an external API). You can write `getServerSideProps` which fetches this data and passes it to `Page` like below:
+
+```jsx
+function Page({ data }) {
+  // Render data...
+}
+
+// This gets called on every request
+export async function getServerSideProps() {
+  // Fetch data from external API
+  const res = await fetch(`https://.../data`);
+  const data = await res.json();
+
+  // Pass data to the page via props
+  return { props: { data } };
+}
+
+export default Page;
+```
+
+As you can see, `getServerSideProps` is similar to `getStaticProps`, but the difference is that `getServerSideProps` is run on every request instead of on build time.
+
+To learn more about how `getServerSideProps` works, check out our [Data Fetching documentation](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering)
+
+## Summary
+
+We've discussed two forms of pre-rendering for Next.js.
+
+- **Static Generation (Recommended):** The HTML is generated at **build time** and will be reused on each request. To make a page use Static Generation, either export the page component, or export `getStaticProps` (and `getStaticPaths` if necessary). It's great for pages that can be pre-rendered ahead of a user's request. You can also use it with Client-side Rendering to bring in additional data.
+- **Server-side Rendering:** The HTML is generated on **each request**. To make a page use Server-side Rendering, export `getServerSideProps`. Because Server-side Rendering results in slower performance than Static Generation, use this only if absolutely necessary.
+
+## Learn more
+
+We recommend you to read the following sections next:
+
+<div class="card">
+  <a href="/docs/basic-features/data-fetching.md">
+    <b>Data Fetching:</b>
+    <small>Learn more about data fetching in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/advanced-features/preview-mode.md">
+    <b>Preview Mode:</b>
+    <small>Learn more about the preview mode in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/routing/introduction.md">
+    <b>Routing:</b>
+    <small>Learn more about routing in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/typescript.md#pages">
+    <b>TypeScript:</b>
+    <small>Add TypeScript to your pages.</small>
+  </a>
+</div>

--- a/docs/basic-features/static-file-serving.md
+++ b/docs/basic-features/static-file-serving.md
@@ -1,0 +1,25 @@
+---
+description: Next.js allows you to serve static files, like images, in the public directory. You can learn how it works here.
+---
+
+# Static File Serving
+
+Next.js can serve static files, like images, under a folder called `public` in the root directory. Files inside `public` can then be referenced by your code starting from the base URL (`/`).
+
+For example, if you add an image to `public/my-image.png`, the following code will access the image:
+
+```jsx
+function MyImage() {
+  return <img src="/my-image.png" alt="my image" />;
+}
+
+export default MyImage;
+```
+
+This folder is also useful for `robots.txt`, Google Site Verification, and any other static files (including `.html`)!
+
+> **Note**: Don't name the `public` directory anything else. The name cannot be changed and is the only directory used to serve static assets.
+
+> **Note**: Be sure to not have a static file with the same name as a file in the `pages/` directory, as this will result in an error.
+>
+> Read more: <http://err.sh/next.js/conflicting-public-file-page>

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -1,0 +1,116 @@
+---
+description: Next.js supports TypeScript by default and has built-in types for pages and the API. You can get started with TypeScript in Next.js here.
+---
+
+# TypeScript
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-typescript">TypeScript</a></li>
+  </ul>
+</details>
+
+Next.js provides an integrated [TypeScript](https://www.typescriptlang.org/) experience out of the box, similar to an IDE.
+
+To get started, create an empty `tsconfig.json` file in the root of your project:
+
+```bash
+touch tsconfig.json
+```
+
+Next.js will automatically configure this file with default values. Providing your own `tsconfig.json` with custom [compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html) is also supported.
+
+> Next.js uses Babel to handle TypeScript, which has some [caveats](https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats), and some [compiler options are handled differently](https://babeljs.io/docs/en/babel-plugin-transform-typescript#typescript-compiler-options).
+
+Then, run `next` (normally `npm run dev`) and Next.js will guide you through the installation of the required packages to finish the setup:
+
+```bash
+npm run dev
+
+# You'll see instructions like these:
+#
+# Please install typescript, @types/react, and @types/node by running:
+#
+#         yarn add --dev typescript @types/react @types/node
+#
+# ...
+```
+
+You're now ready to start converting files from `.js` to `.tsx` and leveraging the benefits of TypeScript!.
+
+> A file named `next-env.d.ts` will be created in the root of your project. This file ensures Next.js types are picked up by the TypeScript compiler. **You cannot remove it**, however, you can edit it (but you don't need to).
+
+> Next.js `strict` mode is turned off by default. When you feel comfortable with TypeScript, it's recommended to turn it on in your `tsconfig.json`.
+
+By default, Next.js reports TypeScript errors during development for pages you are actively working on. TypeScript errors for inactive pages **do not** block the development process.
+
+If you want to silence the error reports, refer to the documentation for [Ignoring TypeScript errors](/docs/api-reference/next.config.js/ignoring-typescript-errors.md).
+
+## Static Generation and Server-side Rendering
+
+For `getStaticProps`, `getStaticPaths`, and `getServerSideProps`, you can use the `GetStaticProps`, `GetStaticPaths`, and `GetServerSideProps` types respectively:
+
+```ts
+import { GetStaticProps, GetStaticPaths, GetServerSideProps } from 'next';
+
+export const getStaticProps: GetStaticProps = async context => {
+  // ...
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // ...
+};
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  // ...
+};
+```
+
+> If you're using `getInitialProps`, you can [follow the directions on this page](/docs/api-reference/data-fetching/getInitialProps.md#typescript).
+
+## API Routes
+
+The following is an example of how to use the built-in types for API routes:
+
+```ts
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default (req: NextApiRequest, res: NextApiResponse) => {
+  res.status(200).json({ name: 'John Doe' });
+};
+```
+
+You can also type the response data:
+
+```ts
+import { NextApiRequest, NextApiResponse } from 'next';
+
+type Data = {
+  name: string;
+};
+
+export default (req: NextApiRequest, res: NextApiResponse<Data>) => {
+  res.status(200).json({ name: 'John Doe' });
+};
+```
+
+## Custom `App`
+
+If you have a [custom `App` ](/docs/advanced-features/custom-app), you can use the built-in type `AppProps` and change file name to `./pages/_app.tsx` like so:
+
+```ts
+import { AppProps } from 'next/app';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;
+```
+
+## Path aliases and baseUrl
+
+Next.js automatically supports the `tsconfig.json` `"paths"` and `"baseUrl"` options.
+
+You can learn more about this feature on the [Module Path aliases documentation](/docs/advanced-features/module-path-aliases.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,77 @@
+---
+description: Deploy your Next.js app to production with Vercel and other hosting options.
+---
+
+# Deployment
+
+## Vercel (Recommended)
+
+The easiest way to deploy Next.js to production is to use the **[Vercel platform](https://vercel.com)** from the creators of Next.js. [Vercel](https://vercel.com) is an all-in-one platform with Global CDN supporting static & JAMstack deployment and Serverless Functions.
+
+### Getting started
+
+If you haven’t already done so, push your Next.js app to a Git provider of your choice: [GitHub](http://github.com/), [GitLab](https://gitlab.com/), or [BitBucket](https://bitbucket.org/). Your repository can be private or public.
+
+Then, follow these steps:
+
+1. [Sign up to Vercel](https://vercel.com/signup) (no credit card is required).
+2. After signing up, you’ll arrive on the [“Import Project”](https://vercel.com/import) page. Under “From Git Repository”, choose the Git provider you use and set up an integration. (Instructions: [GitHub](https://vercel.com/docs/v2/git-integrations/vercel-for-github) / [GitLab](https://vercel.com/docs/v2/git-integrations/vercel-for-gitlab) / [BitBucket](https://vercel.com/docs/v2/git-integrations/vercel-for-bitbucket)).
+3. Once that’s set up, click “Import Project From …” and import your Next.js app. It auto-detects that your app is using Next.js and sets up the build configuration for you. No need to change anything — everything should work just fine!
+4. After importing, it’ll deploy your Next.js app and provide you with a deployment URL. Click “Visit” to see your app in production.
+
+Congratulations! You’ve just deployed your Next.js app! If you have questions, take a look at the [Vercel documentation](https://vercel.com/docs).
+
+> If you’re using a [custom server](/docs/advanced-features/custom-server.md), we strongly recommend migrating away from it (for example, by using [dynamic routing](/docs/routing/dynamic-routes.md)). If you cannot migrate, consider [other hosting options](#other-hosting-options).
+
+### DPS: Develop, Preview, Ship
+
+Let’s talk about the workflow we recommend using. [Vercel](https://vercel.com) supports what we call the **DPS** workflow: **D**evelop, **P**review, and **S**hip:
+
+- **Develop:** Write code in Next.js. Keep the development server running and take advantage of [React Fast Refresh](https://nextjs.org/blog/next-9-4#fast-refresh).
+- **Preview:** Every time you push changes to a branch on GitHub / GitLab / BitBucket, Vercel automatically creates a new deployment with a unique URL. You can view them on GitHub when you open a pull request, or under “Preview Deployments” on your project page on Vercel. [Learn more about it here](https://vercel.com/features/deployment-previews).
+- **Ship:** When you’re ready to ship, merge the pull request to your default branch (e.g. `master`). Vercel will automatically create a production deployment.
+
+By using the DPS workflow, in addition to doing _code reviews_, you can do _deployment previews_. Each deployment creates a unique URL that can be shared or used for integration tests.
+
+### Optimized for Next.js
+
+[Vercel](https://vercel.com) is made by the creators of Next.js and has first-class support for Next.js.
+
+For example, the [hybrid pages](/docs/basic-features/pages.md) approach is fully supported out of the box.
+
+- Every page can either use [Static Generation](/docs/basic-features/pages.md#static-generation) or [Server-Side Rendering](/docs/basic-features/pages.md#server-side-rendering).
+- Pages that use [Static Generation](/docs/basic-features/pages.md#static-generation) and assets (JS, CSS, images, fonts, etc) will automatically be served from the [Vercel Smart CDN](https://vercel.com/smart-cdn), which is blazingly fast.
+- Pages that use [Server-Side Rendering](/docs/basic-features/pages.md#server-side-rendering) and [API routes](/docs/api-routes/introduction.md) will automatically become isolated Serverless Functions. This allows page rendering and API requests to scale infinitely.
+
+### Custom Domains, Environment Variables, Automatic HTTPS, and more
+
+- **Custom Domains:** Once deployed on [Vercel](https://vercel.com), you can assign a custom domain to your Next.js app. Take a look at [our documentation here](https://vercel.com/docs/v2/custom-domains).
+- **Environment Variables:** You can also set environment variables on Vercel. Take a look at [our documentation here](https://vercel.com/docs/v2/build-step#using-environment-variables-and-secrets). You can then [use those environment variables](/docs/api-reference/next.config.js/environment-variables.md) in your Next.js app.
+- **Automatic HTTPS:** HTTPS is enabled by default (including custom domains) and doesn't require extra configuration. We auto-renew SSL certificates.
+- **More:** [Read our documentation](https://vercel.com/docs) to learn more about the Vercel platform.
+
+## Other hosting options
+
+### Node.js Server
+
+Next.js can be deployed to any hosting provider that supports Node.js. This is the approach you should take if you’re using a [custom server](/docs/advanced-features/custom-server.md).
+
+Make sure your `package.json` has the `"build"` and `"start"` scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  }
+}
+```
+
+`next build` builds the production application in the `.next` folder. After building, `next start` starts a Node.js server that supports [hybrid pages](/docs/basic-features/pages.md), serving both statically generated and server-side rendered pages.
+
+### Static HTML Export
+
+If you’d like to do a static HTML export of your Next.js app, follow the directions on [our documentation](/docs/advanced-features/static-html-export.md). By default, `next export` will generate an `out` directory, which can be served by any static hosting service or CDN.
+
+> We strongly recommend using [Vercel](https://vercel.com/) even if your Next.js app is fully static. [Vercel](https://vercel.com/) is optimized to make static Next.js apps blazingly fast. `next export` works with Zero Config deployments on Vercel.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,81 @@
+---
+description: Get to know more about Next.js with the frequently asked questions.
+---
+
+# Frequently Asked Questions
+
+<details>
+  <summary>What browsers are supported?</summary>
+  <p>Next.js supports IE11 and all modern browsers out of the box using <a href="https://new.babeljs.io/docs/en/next/babel-preset-env.html">@babel/preset-env</a>. In order to support IE11 Next.js adds a global Promise polyfill.</p>
+
+  <p>In cases where your own code or any external npm dependencies you are using require features not supported by your target browsers you will need to implement polyfills. If you need to implement polyfills, the <a href="https://github.com/zeit/next.js/tree/canary/examples/with-polyfills">polyfills</a> example demonstrates the recommended approach.</p>
+</details>
+
+<details>
+  <summary>Is this production ready?</summary>
+  <p>Next.js has been powering <a href="https://vercel.com">https://vercel.com</a>  since its inception.</p>
+
+  <p>We’re ecstatic about both the developer experience and end-user performance, so we decided to share it with the community.</p>
+</details>
+
+<details>
+  <summary>How big is it?</summary>
+  <p>The client side bundle size should be measured in a per-app basis. A small Next main bundle is around 65kb gzipped.</p>
+</details>
+
+<details>
+  <summary>How can I change the internal webpack configs?</summary>
+  <p>Next.js tries its best to remove the overhead of webpack configurations, but for advanced cases where more control is needed, refer to the <a href="/docs/api-reference/next.config.js/custom-webpack-config.md">custom webpack config documentation</a>.</p>
+</details>
+
+<details>
+  <summary>What syntactic features are compiled? How do I change them?</summary>
+  <p>We track V8. Since V8 has wide support for ES6 and async and await, we compile those. Since V8 doesn’t support class decorators, we don’t compile those.</p>
+
+  <p>See the documentation about <a href="/docs/advanced-features/customizing-babel-config.md">customizing babel config</a> for more information.</p>
+</details>
+
+<details>
+  <summary>Why a new Router?</summary>
+  Next.js is special in that:
+  <ul>
+    <li>Routes don’t need to be known ahead of time, We don't ship a route manifest</li>
+    <li>Routes are always lazy-loadable</li>
+  </ul>
+</details>
+
+<details>
+  <summary>How do I fetch data?</summary>
+  <p>It's up to you. You can use the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch">fetch API</a> or <a href="https://swr.now.sh/">SWR</a> inside your React components for remote data fetching; or use our <a href="/docs/basic-features/data-fetching.md">data fetching methods</a> for initial data population.</p>
+</details>
+
+<details>
+  <summary>Can I use it with GraphQL?</summary>
+  <p>Yes! Here's an <a href="https://github.com/zeit/next.js/tree/canary/examples/with-apollo">example with Apollo</a>.</p>
+</details>
+
+<details>
+  <summary>Can I use it with Redux?</summary>
+  <p>Yes! Here's an <a href="https://github.com/zeit/next.js/tree/canary/examples/with-redux">example</a>. And there's another <a href="https://github.com/zeit/next.js/tree/canary/examples/with-redux-thunk">example with thunk</a>.</p>
+</details>
+
+<details>
+  <summary>Can I use a CDN for static assets?</summary>
+  <p>Yes. You can read more about it <a href="/docs/api-reference/next.config.js/cdn-support-with-asset-prefix.md">here</a>.</p>
+</details>
+
+<details>
+  <summary>Can I use Next with my favorite JavaScript library or toolkit?</summary>
+  <p>Since our first release we've had many example contributions. You can check them out in the <a href="https://github.com/zeit/next.js/tree/canary/examples">examples</a> directory.</p>
+</details>
+
+<details>
+  <summary>What is this inspired by?</summary>
+  <p>Many of the goals we set out to accomplish were the ones listed in The <a href="https://rauchg.com/2014/7-principles-of-rich-web-applications">7 principles of Rich Web Applications</a> by Guillermo Rauch.</p>
+
+  <p>The ease-of-use of PHP is a great inspiration. We feel Next.js is a suitable replacement for many scenarios where you would otherwise use PHP to output HTML.</p>
+
+  <p>Unlike PHP, we benefit from the ES6 module system and every page exports a component or function that can be easily imported for lazy evaluation or testing.</p>
+
+  <p>As we were researching options for server-rendering React that didn’t involve a large number of steps, we came across <a href="https://github.com/facebookarchive/react-page">react-page</a> (now deprecated), a similar approach to Next.js by the creator of React Jordan Walke.</p>
+</details>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,108 @@
+---
+description: Get started with Next.js in the official documentation, and learn more about all our features!
+---
+
+# Getting Started
+
+Welcome to the Next.js documentation!
+
+If you're new to Next.js we recommend that you start with the [learn course](https://nextjs.org/learn/basics/getting-started).
+
+The interactive course with quizzes will guide you through everything you need to know to use Next.js.
+
+If you have questions about anything related to Next.js, you're always welcome to ask our community on [GitHub Discussions](https://github.com/zeit/next.js/discussions).
+
+#### System Requirements
+
+- [Node.js 10.13](https://nodejs.org/) or later
+- MacOS, Windows (including WSL), and Linux are supported
+
+## Setup
+
+We recommend creating a new Next.js app using `create-next-app`, which sets up everything automatically for you. To create a project, run:
+
+```bash
+npx create-next-app
+# or
+yarn create next-app
+```
+
+After the installation is complete, follow the instructions to start the development server. Try editing `pages/index.js` and see the result on your browser.
+
+## Manual Setup
+
+Install `next`, `react` and `react-dom` in your project:
+
+```bash
+npm install next react react-dom
+```
+
+Open `package.json` and add the following `scripts`:
+
+```json
+"scripts": {
+  "dev": "next",
+  "build": "next build",
+  "start": "next start"
+}
+```
+
+These scripts refer to the different stages of developing an application:
+
+- `dev` - Runs `next` which starts Next.js in development mode
+- `build` - Runs `next build` which builds the application for production usage
+- `start` - Runs `next start` which starts a Next.js production server
+
+Next.js is built around the concept of pages. A page is a [React Component](https://reactjs.org/docs/components-and-props.html) exported from a `.js`, `.jsx`, `.ts`, or `.tsx` file in the `pages` directory.
+
+Pages are associated with a route based on their file name. For example `pages/about.js` is mapped to `/about`. You can even add dynamic route parameters with the filename.
+
+Create a `pages` directory inside your project.
+
+Populate `./pages/index.js` with the following contents:
+
+```jsx
+function HomePage() {
+  return <div>Welcome to Next.js!</div>;
+}
+
+export default HomePage;
+```
+
+To start developing your application run `npm run dev`. This starts the development server on `http://localhost:3000`.
+
+Visit `http://localhost:3000` to view your application.
+
+So far, we get:
+
+- Automatic compilation and bundling (with webpack and babel)
+- [React Fast Refresh](https://nextjs.org/blog/next-9-4#fast-refresh)
+- [Static generation and server-side rendering](/docs/basic-features/data-fetching.md) of [`./pages/`](/docs/basic-features/pages.md)
+- [Static file serving](/docs/basic-features/static-file-serving.md). `./public/` is mapped to `/`
+
+In addition, any Next.js application is ready for production from the start, read more in our [Deployment documentation](/docs/deployment.md).
+
+## Related
+
+For more information on what to do next, we recommend the following sections:
+
+<div class="card">
+  <a href="/docs/basic-features/pages.md">
+    <b>Pages:</b>
+    <small>Learn more about what pages are in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/built-in-css-support.md">
+    <b>CSS Support:</b>
+    <small>Use the built-in CSS support to add custom styles to your app.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/api-reference/cli.md">
+    <b>CLI:</b>
+    <small>Learn more about the Next.js CLI.</small>
+  </a>
+</div>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,279 @@
+{
+  "routes": [
+    {
+      "title": "Documentation",
+      "heading": true,
+      "routes": [
+        { "title": "Getting Started", "path": "/docs/getting-started.md" },
+        {
+          "title": "Basic Features",
+          "open": true,
+          "routes": [
+            {
+              "title": "Pages",
+              "path": "/docs/basic-features/pages.md"
+            },
+            {
+              "title": "Data fetching",
+              "path": "/docs/basic-features/data-fetching.md"
+            },
+            {
+              "title": "Built-in CSS Support",
+              "path": "/docs/basic-features/built-in-css-support.md"
+            },
+            {
+              "title": "Static File Serving",
+              "path": "/docs/basic-features/static-file-serving.md"
+            },
+            {
+              "title": "TypeScript",
+              "path": "/docs/basic-features/typescript.md"
+            },
+            {
+              "title": "Environment Variables",
+              "path": "/docs/basic-features/environment-variables.md"
+            }
+          ]
+        },
+        {
+          "title": "Routing",
+          "routes": [
+            {
+              "title": "Introduction",
+              "path": "/docs/routing/introduction.md"
+            },
+            {
+              "title": "Dynamic Routes",
+              "path": "/docs/routing/dynamic-routes.md"
+            },
+            {
+              "title": "Imperatively",
+              "path": "/docs/routing/imperatively.md"
+            },
+            {
+              "title": "Shallow Routing",
+              "path": "/docs/routing/shallow-routing.md"
+            }
+          ]
+        },
+        {
+          "title": "API Routes",
+          "routes": [
+            {
+              "title": "Introduction",
+              "path": "/docs/api-routes/introduction.md"
+            },
+            {
+              "title": "Dynamic API Routes",
+              "path": "/docs/api-routes/dynamic-api-routes.md"
+            },
+            {
+              "title": "API Middlewares",
+              "path": "/docs/api-routes/api-middlewares.md"
+            },
+            {
+              "title": "Response Helpers",
+              "path": "/docs/api-routes/response-helpers.md"
+            }
+          ]
+        },
+        {
+          "title": "Deployment",
+          "path": "/docs/deployment.md"
+        },
+        {
+          "title": "Advanced Features",
+          "routes": [
+            {
+              "title": "Preview Mode",
+              "path": "/docs/advanced-features/preview-mode.md"
+            },
+            {
+              "title": "Dynamic Import",
+              "path": "/docs/advanced-features/dynamic-import.md"
+            },
+            {
+              "title": "Automatic Static Optimization",
+              "path": "/docs/advanced-features/automatic-static-optimization.md"
+            },
+            {
+              "title": "Static HTML Export",
+              "path": "/docs/advanced-features/static-html-export.md"
+            },
+            {
+              "title": "Absolute Imports and Module Path Aliases",
+              "path": "/docs/advanced-features/module-path-aliases.md"
+            },
+            {
+              "title": "AMP Support",
+              "routes": [
+                {
+                  "title": "Introduction",
+                  "path": "/docs/advanced-features/amp-support/introduction.md"
+                },
+                {
+                  "title": "Adding AMP Components",
+                  "path": "/docs/advanced-features/amp-support/adding-amp-components.md"
+                },
+                {
+                  "title": "AMP Validation",
+                  "path": "/docs/advanced-features/amp-support/amp-validation.md"
+                },
+                {
+                  "title": "AMP in Static HTML export",
+                  "path": "/docs/advanced-features/amp-support/amp-in-static-html-export.md"
+                },
+                {
+                  "title": "TypeScript",
+                  "path": "/docs/advanced-features/amp-support/typescript.md"
+                }
+              ]
+            },
+            {
+              "title": "Customizing Babel Config",
+              "path": "/docs/advanced-features/customizing-babel-config.md"
+            },
+            {
+              "title": "Customizing PostCSS Config",
+              "path": "/docs/advanced-features/customizing-postcss-config.md"
+            },
+            {
+              "title": "Custom Server",
+              "path": "/docs/advanced-features/custom-server.md"
+            },
+            {
+              "title": "Custom `App`",
+              "path": "/docs/advanced-features/custom-app.md"
+            },
+            {
+              "title": "Custom `Document`",
+              "path": "/docs/advanced-features/custom-document.md"
+            },
+            {
+              "title": "Custom Error Page",
+              "path": "/docs/advanced-features/custom-error-page.md"
+            },
+            {
+              "title": "`src` Directory",
+              "path": "/docs/advanced-features/src-directory.md"
+            },
+            {
+              "title": "Multi Zones",
+              "path": "/docs/advanced-features/multi-zones.md"
+            },
+            {
+              "title": "Measuring performance",
+              "path": "/docs/advanced-features/measuring-performance.md"
+            }
+          ]
+        },
+        {
+          "title": "Upgrade Guide",
+          "path": "/docs/upgrading.md"
+        },
+        { "title": "FAQ", "path": "/docs/faq.md" }
+      ]
+    },
+    {
+      "title": "API Reference",
+      "heading": true,
+      "routes": [
+        { "title": "CLI", "path": "/docs/api-reference/cli.md" },
+        {
+          "title": "next/router",
+          "path": "/docs/api-reference/next/router.md"
+        },
+        {
+          "title": "next/link",
+          "path": "/docs/api-reference/next/link.md"
+        },
+        {
+          "title": "next/head",
+          "path": "/docs/api-reference/next/head.md"
+        },
+        {
+          "title": "next/amp",
+          "path": "/docs/api-reference/next/amp.md"
+        },
+        {
+          "title": "Data Fetching",
+          "routes": [
+            {
+              "title": "getInitialProps",
+              "path": "/docs/api-reference/data-fetching/getInitialProps.md"
+            }
+          ]
+        },
+        {
+          "title": "next.config.js",
+          "routes": [
+            {
+              "title": "Introduction",
+              "path": "/docs/api-reference/next.config.js/introduction.md"
+            },
+            {
+              "title": "Environment Variables",
+              "path": "/docs/api-reference/next.config.js/environment-variables.md"
+            },
+            {
+              "title": "Custom Page Extensions",
+              "path": "/docs/api-reference/next.config.js/custom-page-extensions.md"
+            },
+            {
+              "title": "CDN Support with Asset Prefix",
+              "path": "/docs/api-reference/next.config.js/cdn-support-with-asset-prefix.md"
+            },
+            {
+              "title": "Build Target",
+              "path": "/docs/api-reference/next.config.js/build-target.md"
+            },
+            {
+              "title": "Custom Webpack Config",
+              "path": "/docs/api-reference/next.config.js/custom-webpack-config.md"
+            },
+            {
+              "title": "Compression",
+              "path": "/docs/api-reference/next.config.js/compression.md"
+            },
+            {
+              "title": "Static Optimization Indicator",
+              "path": "/docs/api-reference/next.config.js/static-optimization-indicator.md"
+            },
+            {
+              "title": "Runtime Configuration",
+              "path": "/docs/api-reference/next.config.js/runtime-configuration.md"
+            },
+            {
+              "title": "Disabling x-powered-by",
+              "path": "/docs/api-reference/next.config.js/disabling-x-powered-by.md"
+            },
+            {
+              "title": "Disabling ETag Generation",
+              "path": "/docs/api-reference/next.config.js/disabling-etag-generation.md"
+            },
+            {
+              "title": "Setting a custom build directory",
+              "path": "/docs/api-reference/next.config.js/setting-a-custom-build-directory.md"
+            },
+            {
+              "title": "Configuring the Build ID",
+              "path": "/docs/api-reference/next.config.js/configuring-the-build-id.md"
+            },
+            {
+              "title": "Configuring onDemandEntries",
+              "path": "/docs/api-reference/next.config.js/configuring-onDemandEntries.md"
+            },
+            {
+              "title": "Ignoring TypeScript Errors",
+              "path": "/docs/api-reference/next.config.js/ignoring-typescript-errors.md"
+            },
+            {
+              "title": "exportPathMap",
+              "path": "/docs/api-reference/next.config.js/exportPathMap.md"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/routing/dynamic-routes.md
+++ b/docs/routing/dynamic-routes.md
@@ -1,0 +1,110 @@
+---
+description: Dynamic Routes are pages that allow you to add custom params to your URLs. Start creating Dynamic Routes and learn more here.
+---
+
+# Dynamic Routes
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/dynamic-routing">Dynamic Routing</a></li>
+  </ul>
+</details>
+
+Defining routes by using predefined paths is not always enough for complex applications. In Next.js you can add brackets to a page (`[param]`) to create a dynamic route (a.k.a. url slugs, pretty urls, and others).
+
+Consider the following page `pages/post/[pid].js`:
+
+```jsx
+import { useRouter } from 'next/router';
+
+const Post = () => {
+  const router = useRouter();
+  const { pid } = router.query;
+
+  return <p>Post: {pid}</p>;
+};
+
+export default Post;
+```
+
+Any route like `/post/1`, `/post/abc`, etc. will be matched by `pages/post/[pid].js`. The matched path parameter will be sent as a query parameter to the page, and it will be merged with the other query parameters.
+
+For example, the route `/post/abc` will have the following `query` object:
+
+```json
+{ "pid": "abc" }
+```
+
+Similarly, the route `/post/abc?foo=bar` will have the following `query` object:
+
+```json
+{ "foo": "bar", "pid": "abc" }
+```
+
+However, route parameters will override query parameters with the same name. For example, the route `/post/abc?pid=123` will have the following `query` object:
+
+```json
+{ "pid": "abc" }
+```
+
+Multiple dynamic route segments work the same way. The page `pages/post/[pid]/[comment].js` will match the route `/post/abc/a-comment` and its `query` object will be:
+
+```json
+{ "pid": "abc", "comment": "a-comment" }
+```
+
+Client-side navigations to a dynamic route can be handled with [`next/link`](/docs/api-reference/next/link.md#dynamic-routes).
+
+### Catch all routes
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/catch-all-routes">Catch All Routes</a></li>
+  </ul>
+</details>
+
+Dynamic routes can be extended to catch all paths by adding three dots (`...`) inside the brackets. For example:
+
+- `pages/post/[...slug].js` matches `/post/a`, but also `/post/a/b`, `/post/a/b/c` and so on.
+
+> **Note**: You can use names other than `slug`, such as: `[...param]`
+
+Matched parameters will be sent as a query parameter (`slug` in the example) to the page, and it will always be an array, so, the path `/post/a` will have the following `query` object:
+
+```json
+{ "slug": ["a"] }
+```
+
+And in the case of `/post/a/b`, and any other matching path, new parameters will be added to the array, like so:
+
+```json
+{ "slug": ["a", "b"] }
+```
+
+> A good example of catch all routes is the Next.js docs, a single page called [pages/docs/[...slug].js](https://github.com/zeit/next-site/blob/master/pages/docs/%5B...slug%5D.js) takes care of all the docs you're currently looking at.
+
+### Optional catch all routes
+
+Catch all routes can be made optional by including the parameter in double brackets (`[[...slug]]`).
+
+For example, `pages/post/[[...slug]].js` will match `/post`, `/post/a`, `/post/a/b`, and so on.
+
+The `query` objects are as follows:
+
+```json
+{ } // GET `/post` (empty object)
+{ "slug": ["a"] } // `GET /post/a` (single-element array)
+{ "slug": ["a", "b"] } // `GET /post/a/b` (multi-element array)
+```
+
+## Caveats
+
+- Predefined routes take precedence over dynamic routes, and dynamic routes over catch all routes. Take a look at the following examples:
+  - `pages/post/create.js` - Will match `/post/create`
+  - `pages/post/[pid].js` - Will match `/post/1`, `/post/abc`, etc. But not `/post/create`
+  - `pages/post/[...slug].js` - Will match `/post/1/2`, `/post/a/b/c`, etc. But not `/post/create`, `/post/abc`
+- Pages that are statically optimized by [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) will be hydrated without their route parameters provided, i.e `query` will be an empty object (`{}`).
+
+  After hydration, Next.js will trigger an update to your application to provide the route parameters in the `query` object.

--- a/docs/routing/imperatively.md
+++ b/docs/routing/imperatively.md
@@ -1,0 +1,30 @@
+---
+description: Client-side navigations are also possible using the Router API instead of the Link component. Learn more here.
+---
+
+# Imperatively
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/using-router">Using Router</a></li>
+  </ul>
+</details>
+
+[`next/link`](/docs/api-reference/next/link.md) should be able to cover most of your routing needs, but you can also do client-side navigations without it, take a look at the [Router API documentation](/docs/api-reference/next/router.md#router-api).
+
+The following example shows the basic usage of the Router API:
+
+```jsx
+import Router from 'next/router';
+
+function ReadMore() {
+  return (
+    <div>
+      Click <span onClick={() => Router.push('/about')}>here</span> to read more
+    </div>
+  );
+}
+
+export default ReadMore;
+```

--- a/docs/routing/introduction.md
+++ b/docs/routing/introduction.md
@@ -1,0 +1,134 @@
+---
+description: Next.js has a built-in, opinionated, and file-system based Router. You can learn how it works here.
+---
+
+# Routing
+
+Next.js has a file-system based router built on the [concept of pages](/docs/basic-features/pages.md).
+
+When a file is added to the `pages` directory it's automatically available as a route.
+
+The files inside the `pages` directory can be used to define most common patterns.
+
+#### Index routes
+
+The router will automatically route files named `index` to the root of the directory.
+
+- `pages/index.js` → `/`
+- `pages/blog/index.js` → `/blog`
+
+#### Nested routes
+
+The router supports nested files. If you create a nested folder structure files will be automatically routed in the same way still.
+
+- `pages/blog/first-post.js` → `/blog/first-post`
+- `pages/dashboard/settings/username.js` → `/dashboard/settings/username`
+
+#### Dynamic route segments
+
+To match a dynamic segment you can use the bracket syntax. This allows you to match named parameters.
+
+- `pages/blog/[slug].js` → `/blog/:slug` (`/blog/hello-world`)
+- `pages/[username]/settings.js` → `/:username/settings` (`/foo/settings`)
+- `pages/post/[...all].js` → `/post/*` (`/post/2020/id/title`)
+
+## Linking between pages
+
+The Next.js router allows you to do client-side route transitions between pages, similarly to a single-page application.
+
+A React component called `Link` is provided to do this client-side route transition.
+
+```jsx
+import Link from 'next/link';
+
+function Home() {
+  return (
+    <ul>
+      <li>
+        <Link href="/">
+          <a>Home</a>
+        </Link>
+      </li>
+      <li>
+        <Link href="/about">
+          <a>About Us</a>
+        </Link>
+      </li>
+    </ul>
+  );
+}
+
+export default Home;
+```
+
+When linking to a route with [dynamic path segments](/docs/routing/dynamic-routes.md) you have to provide `href` and `as` to make sure the router knows which JavaScript file to load.
+
+- `href` - The name of the page in the `pages` directory. For example `/blog/[slug]`.
+- `as` - The url that will be shown in the browser. For example `/blog/hello-world`.
+
+```jsx
+import Link from 'next/link';
+
+function Home() {
+  return (
+    <ul>
+      <li>
+        <Link href="/blog/[slug]" as="/blog/hello-world">
+          <a>To Hello World Blog post</a>
+        </Link>
+      </li>
+    </ul>
+  );
+}
+
+export default Home;
+```
+
+The `as` prop can also be generated dynamically. For example, to show a list of posts which have been passed to the page as a prop:
+
+```jsx
+function Home({ posts }) {
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.id}>
+          <Link href="/blog/[slug]" as={`/blog/${post.slug}`}>
+            <a>{post.title}</a>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+## Injecting the router
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/dynamic-routing">Dynamic Routing</a></li>
+  </ul>
+</details>
+
+To access the [`router` object](/docs/api-reference/next/router.md#router-object) in a React component you can use [`useRouter`](/docs/api-reference/next/router.md#useRouter) or [`withRouter`](/docs/api-reference/next/router.md#withRouter).
+
+In general we recommend using [`useRouter`](/docs/api-reference/next/router.md#useRouter).
+
+## Learn more
+
+The router is divided in multiple parts:
+
+<div class="card">
+  <a href="/docs/api-reference/next/link.md">
+    <b>next/link:</b>
+    <small>Handle client-side navigations.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/api-reference/next/router.md">
+    <b>next/router:</b>
+    <small>Leverage the router API in your pages.</small>
+  </a>
+</div>

--- a/docs/routing/shallow-routing.md
+++ b/docs/routing/shallow-routing.md
@@ -1,0 +1,71 @@
+---
+description: You can use shallow routing to change the URL without triggering a new page change. Learn more here.
+---
+
+# Shallow Routing
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-shallow-routing">Shallow Routing</a></li>
+  </ul>
+</details>
+
+Shallow routing allows you to change the URL without running data fetching methods again, that includes [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering), [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation), and [`getInitialProps`](/docs/api-reference/data-fetching/getInitialProps.md).
+
+You'll receive the updated `pathname` and the `query` via the [`router` object](/docs/api-reference/next/router.md#router-object) (added by [`useRouter`](/docs/api-reference/next/router.md#useRouter) or [`withRouter`](/docs/api-reference/next/router.md#withRouter)), without losing state.
+
+To enable shallow routing, set the `shallow` option to `true`. Consider the following example:
+
+```jsx
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+// Current URL is '/'
+function Page() {
+  const router = useRouter();
+
+  useEffect(() => {
+    // Always do navigations after the first render
+    router.push('/?counter=10', undefined, { shallow: true });
+  }, []);
+
+  useEffect(() => {
+    // The counter changed!
+  }, [router.query.counter]);
+}
+
+export default Page;
+```
+
+If you don't need to add the router object to the page, you can also use the [Router API](/docs/api-reference/next/router.md#router-api) directly, like so:
+
+```jsx
+import Router from 'next/router';
+// Inside your page
+Router.push('/?counter=10', undefined, { shallow: true });
+```
+
+The URL will get updated to `/?counter=10`. and the page won't get replaced, only the state of the route is changed.
+
+You can also watch for URL changes via [`componentDidUpdate`](https://reactjs.org/docs/react-component.html#componentdidupdate) as shown below:
+
+```jsx
+componentDidUpdate(prevProps) {
+  const { pathname, query } = this.props.router
+  // verify props have changed to avoid an infinite loop
+  if (query.counter !== prevProps.router.query.counter) {
+    // fetch data based on the new query
+  }
+}
+```
+
+## Caveats
+
+Shallow routing **only** works for same page URL changes. For example, let's assume we have another page called `pages/about.js`, and you run this:
+
+```jsx
+Router.push('/?counter=10', '/about?counter=10', { shallow: true });
+```
+
+Since that's a new page, it'll unload the current page, load the new one and wait for data fetching even though we asked to do shallow routing.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,216 @@
+---
+description: Learn how to upgrade Next.js.
+---
+
+# Upgrade Guide
+
+## Upgrading from version 8 to 9.0.x
+
+### Preamble
+
+#### Production Deployment on Vercel
+
+If you previously configured `routes` in your `now.json` file for dynamic routes, these rules can be removed when leveraging Next.js 9's new [Dynamic Routing feature](https://nextjs.org/docs/routing/dynamic-routes).
+
+Next.js 9's dynamic routes are **automatically configured on [Now](https://vercel.com/now)** and do not require any `now.json` customization.
+
+You can read more about [Dynamic Routing here](https://nextjs.org/docs/routing/dynamic-routes).
+
+#### Check your Custom <App> (`pages/_app.js`)
+
+If you previously copied the [Custom `<App>`](https://nextjs.org/docs#custom-app) example, you may be able to remove your `getInitialProps`.
+
+Removing `getInitialProps` from `pages/_app.js` (when possible) is important to leverage new Next.js features!
+
+The following `getInitialProps` does nothing and may be removed:
+
+```js
+class MyApp extends App {
+  // Remove me, I do nothing!
+  static async getInitialProps({ Component, ctx }) {
+    let pageProps = {};
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx);
+    }
+
+    return { pageProps };
+  }
+
+  render() {
+    // ... etc
+  }
+}
+```
+
+### Breaking Changes
+
+#### `@zeit/next-typescript` is no longer necessary
+
+Next.js will now ignore usage `@zeit/next-typescript` and warn you to remove it. Please remove this plugin from your `next.config.js`.
+
+Remove references to `@zeit/next-typescript/babel` from your custom `.babelrc` (if present).
+
+Usage of [`fork-ts-checker-webpack-plugin`](https://github.com/Realytics/fork-ts-checker-webpack-plugin/issues) should also be removed from your `next.config.js`.
+
+TypeScript Definitions are published with the `next` package, so you need to uninstall `@types/next` as they would conflict.
+
+The following types are different:
+
+> This list was created by the community to help you upgrade, if you find other differences please send a pull-request to this list to help other users.
+
+From:
+
+```tsx
+import { NextContext } from 'next';
+import { NextAppContext, DefaultAppIProps } from 'next/app';
+import { NextDocumentContext, DefaultDocumentIProps } from 'next/document';
+```
+
+to
+
+```tsx
+import { NextPageContext } from 'next';
+import { AppContext, AppInitialProps } from 'next/app';
+import { DocumentContext, DocumentInitialProps } from 'next/document';
+```
+
+#### The `config` key is now a special export on a page
+
+You may no longer export a custom variable named `config` from a page (i.e. `export { config }` / `export const config ...`).
+This exported variable is now used to specify page-level Next.js configuration like Opt-in AMP and API Route features.
+
+You must rename a non-Next.js-purposed `config` export to something different.
+
+#### `next/dynamic` no longer renders "loading..." by default while loading
+
+Dynamic components will not render anything by default while loading. You can still customize this behavior by setting the `loading` property:
+
+```jsx
+import dynamic from 'next/dynamic';
+
+const DynamicComponentWithCustomLoading = dynamic(() => import('../components/hello2'), {
+  loading: () => <p>Loading</p>
+});
+```
+
+#### `withAmp` has been removed in favor of an exported configuration object
+
+Next.js now has the concept of page-level configuration, so the `withAmp` higher-order component has been removed for consistency.
+
+This change can be **automatically migrated by running the following commands in the root of your Next.js project:**
+
+```bash
+curl -L https://github.com/zeit/next-codemod/archive/master.tar.gz | tar -xz --strip=2 next-codemod-master/transforms/withamp-to-config.js npx jscodeshift -t ./withamp-to-config.js pages/**/*.js
+```
+
+To perform this migration by hand, or view what the codemod will produce, see below:
+
+**Before**
+
+```jsx
+import { withAmp } from 'next/amp';
+
+function Home() {
+  return <h1>My AMP Page</h1>;
+}
+
+export default withAmp(Home);
+// or
+export default withAmp(Home, { hybrid: true });
+```
+
+**After**
+
+```jsx
+export default function Home() {
+  return <h1>My AMP Page</h1>;
+}
+
+export const config = {
+  amp: true,
+  // or
+  amp: 'hybrid'
+};
+```
+
+#### `next export` no longer exports pages as `index.html`
+
+Previously, exporting `pages/about.js` would result in `out/about/index.html`. This behavior has been changed to result in `out/about.html`.
+
+You can revert to the previous behavior by creating a `next.config.js` with the following content:
+
+```js
+// next.config.js
+module.exports = {
+  exportTrailingSlash: true
+};
+```
+
+#### `./pages/api/` is treated differently
+
+Pages in `./pages/api/` are now considered [API Routes](https://nextjs.org/blog/next-9#api-routes).
+Pages in this directory will no longer contain a client-side bundle.
+
+## Deprecated Features
+
+#### `next/dynamic` has deprecated loading multiple modules at once
+
+The ability to load multiple modules at once has been deprecated in `next/dynamic` to be closer to React's implementation (`React.lazy` and `Suspense`).
+
+Updating code that relies on this behavior is relatively straightforward! We've provided an example of a before/after to help you migrate your application:
+
+**Before**
+
+```jsx
+import dynamic from 'next/dynamic';
+
+const HelloBundle = dynamic({
+  modules: () => {
+    const components = {
+      Hello1: () => import('../components/hello1').then(m => m.default),
+      Hello2: () => import('../components/hello2').then(m => m.default)
+    };
+
+    return components;
+  },
+  render: (props, { Hello1, Hello2 }) => (
+    <div>
+      <h1>{props.title}</h1>
+      <Hello1 />
+      <Hello2 />
+    </div>
+  )
+});
+
+function DynamicBundle() {
+  return <HelloBundle title="Dynamic Bundle" />;
+}
+
+export default DynamicBundle;
+```
+
+**After**
+
+```jsx
+import dynamic from 'next/dynamic';
+
+const Hello1 = dynamic(() => import('../components/hello1'));
+const Hello2 = dynamic(() => import('../components/hello2'));
+
+function HelloBundle({ title }) {
+  return (
+    <div>
+      <h1>{title}</h1>
+      <Hello1 />
+      <Hello2 />
+    </div>
+  );
+}
+
+function DynamicBundle() {
+  return <HelloBundle title="Dynamic Bundle" />;
+}
+
+export default DynamicBundle;
+```

--- a/lib/docs/markdown-to-html.js
+++ b/lib/docs/markdown-to-html.js
@@ -43,10 +43,10 @@ const getProcessor = unified()
   .use(html)
   .freeze();
 
-export default async function markdownToHtml(filePath, tag, md) {
+export default async function markdownToHtml(filePath, md) {
   try {
     // Init the processor with our custom plugin
-    const processor = getProcessor().use(docs, { filePath, tag });
+    const processor = getProcessor().use(docs, { filePath });
     const file = await processor.process(md);
 
     // Replace non-breaking spaces (char code 160) with normal spaces to avoid style issues

--- a/lib/docs/page.js
+++ b/lib/docs/page.js
@@ -1,5 +1,5 @@
 import { getLatestTag } from '../github/api';
-import { getRawFileFromRepo } from '../github/raw';
+import { getRawFileFromRepo, getRawFileFromLocalProject } from '../github/raw';
 import { removeFromLast } from './utils';
 import { TAG, FORCE_TAG } from './config';
 
@@ -9,8 +9,10 @@ export async function getCurrentTag(tag) {
   return getLatestTag();
 }
 
-export async function fetchDocsManifest(tag) {
-  const res = await getRawFileFromRepo('/docs/manifest.json', tag);
+export async function fetchDocsManifest() {
+  const res = process.env.isProd
+    ? await getRawFileFromRepo('/docs/manifest.json')
+    : await getRawFileFromLocalProject('/docs/manifest.json');
   return JSON.parse(res);
 }
 

--- a/lib/github/constants.js
+++ b/lib/github/constants.js
@@ -4,4 +4,4 @@ export const GITHUB_API_URL = 'https://api.github.com';
 
 export const RAW_GITHUB_URL = 'https://raw.githubusercontent.com';
 
-export const REPO_NAME = 'zeit/next.js';
+export const REPO_NAME = 'Nextjs-ja-translation/Nextjs-ja-translation-docs';

--- a/lib/github/raw.js
+++ b/lib/github/raw.js
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import pathMod from 'path';
 import fetch from '../fetch';
 import { RAW_GITHUB_URL, REPO_NAME } from './constants';
 
@@ -26,6 +28,10 @@ export async function getRawFileFromGitHub(path) {
   throw await getError(res);
 }
 
-export function getRawFileFromRepo(path, tag) {
-  return getRawFileFromGitHub(`/${REPO_NAME}/${tag}${path}`);
+export function getRawFileFromRepo(path) {
+  return getRawFileFromGitHub(`/${REPO_NAME}/${path}`);
+}
+
+export async function getRawFileFromLocalProject(path) {
+  return fs.readFileSync(pathMod.join(process.cwd(), path), 'utf8');
 }

--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,7 @@ const withGitHubMDX = nextMDX({
       [
         rehypeReadme,
         {
-          repo: 'zeit/next.js',
+          repo: 'Nextjs-ja-translation/Nextjs-ja-translation-docs',
           branch: 'master',
           level: 4
         }
@@ -112,6 +112,9 @@ const excelLessonsRedirect = [].concat(
 const nextConfig = {
   target: 'experimental-serverless-trace', // Not required for Now, but used by GitHub Actions
   pageExtensions: ['jsx', 'js', 'ts', 'tsx', 'mdx'],
+  env: {
+    isProd: process.env.NODE_ENV === 'production'
+  },
   experimental: {
     modern: true,
     rewrites() {


### PR DESCRIPTION
## Background 

現在 `next-site` の新バージョンのdocsは実は `zeit/next-site` 下にあるのではなく, `zeit/nextjs`にある.
そして `getStaticProps` でそこからmdを持ってくる形を取っていて, それに合わせるためにこのレポジトリの root に `docs` を置き新バージョンのdocsを持ってきた.
ついでに `getStaticProps` で参照するレポジトリもここに変更しました