### PR TITLE
feat: READMEにall contributorsを表示するためのタグを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 help needed
+
+## Contributors ✨
+
+Thanks to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
## WHY

READMEにall contributorsを表示するためのタグを追加しておきたい

今やっておかないと, contributors増えてからだと少しめんどくさいため