### PR TITLE
Chore: .prettierignoreにdocs追加とtextlintの設定追加

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ pages/blog/next-5.mdx
 pages/blog/next-5-1.mdx
 pages/blog/next-6.mdx
 pages/blog/next-6-1.mdx
+
+docs

--- a/.textlintrc
+++ b/.textlintrc
@@ -6,6 +6,9 @@
         "allowFullWidthQuestion": true,
       }
     },
+    "ja-technical-writing/ja-no-mixed-period": {
+      "allowPeriodMarks": [":"],
+    },
     "prh": {
       "rulePaths" :[
         "rules.yml"


### PR DESCRIPTION
翻訳作業をしている中で、設定関連で気になる点があったので追加しておきました。

- .prettierignoreにdocsを追加して、docs以下は整形しないようにする
- 末尾がセミコロンで終わる文章があるので、textlintにセミコロンを許可設定。

確認よろしくお願いします。