### PR TITLE
docs: fix create branch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ yarn dev
 翻訳作業を行うためのブランチを作成します。ここでは、例として`docs/example.md`を翻訳するためのブランチを作成します。
 
 ```
-$ git checkout -b docs/example
+$ git checkout -b docs/example.md
 ```
 
 これで、翻訳を始める準備は完了です。エディタを使って、翻訳箇所のファイルを編集します。

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ yarn dev
 翻訳作業を行うためのブランチを作成します。ここでは、例として`docs/example.md`を翻訳するためのブランチを作成します。
 
 ```
-$ git switch -c docs/example.md
+$ git checkout -b docs/example
 ```
 
 これで、翻訳を始める準備は完了です。エディタを使って、翻訳箇所のファイルを編集します。


### PR DESCRIPTION
## 変更内容
- 1. `switch -c` -> `checkout -b`
- 2. `docs/example.md` -> `docs/example`

## その理由について
- 1. switchコマンドが利用できる2.23.0以前の場合は使う場合バージョンアップが必要になる&まだ実験的なコマンドなので
- 2. ファイル名ではなくブランチ名なので.mdは不要かなと

https://git-scm.com/docs/git-switch