### PR TITLE
fix: README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ yarn dev
 翻訳作業を行うためのブランチを作成します。ここでは、例として`docs/example.md`を翻訳するためのブランチを作成します。
 
 ```
-$ git checkout -b docs/example.md
+$ git checkout -b docs/example
 ```
 
 これで、翻訳を始める準備は完了です。エディタを使って、翻訳箇所のファイルを編集します。


### PR DESCRIPTION
@yokinist さんに、ブランチ名に`.md`含めるのは分かりづらいと指摘を頂いたので修正します。確認よろしくお願いします。

変更前
```
$ git checkout -b docs/example.md
```

変更後
```
$ git checkout -b docs/example
```