### PR TITLE
chore: disabled ja-technical-writing/sentence-length

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -9,6 +9,7 @@
     "ja-technical-writing/ja-no-mixed-period": {
       "allowPeriodMarks": [":"],
     },
+    "ja-technical-writing/sentence-length": false, //100文字数制限の無効化
     "prh": {
       "rulePaths" :[
         "rules.yml"


### PR DESCRIPTION
@yamanokuさんと@YopiNojiさんが100文字を超える翻訳箇所があったため、textlintの`ja-technical-writing/sentence-length`を無効化しました。

該当箇所のPR #62

確認よろしくお願いします。