### PR TITLE
chore: add spacing rule to textlint

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,3 +1,3 @@
 "hooks": {
-  "pre-commit": "lint-staged"
+  "pre-commit": "lint-staged && pretty-quick --staged"
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,4 @@
 {
-  "*": ["pretty-quick --staged"],
   "*.md": [
     "textlint --fix",
     "textlint"

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,7 @@
 {
   "*": ["pretty-quick --staged"],
-  "*.md": ["textlint"],
+  "*.md": [
+    "textlint --fix",
+    "textlint"
+  ]
 }

--- a/.textlintrc
+++ b/.textlintrc
@@ -6,7 +6,16 @@
         "allowFullWidthQuestion": true,
       }
     },
-    "preset-ja-spacing": true,
+    "preset-ja-spacing": {
+      "ja-space-between-half-and-full-width": {
+        space: "always",
+        exceptPunctuation: true,
+      },
+      "ja-space-around-code": {
+        "before": true,
+        "after": true
+      }
+    },
     "ja-technical-writing/ja-no-mixed-period": {
       "allowPeriodMarks": [":"],
     },

--- a/.textlintrc
+++ b/.textlintrc
@@ -6,6 +6,7 @@
         "allowFullWidthQuestion": true,
       }
     },
+    "preset-ja-spacing": true,
     "ja-technical-writing/ja-no-mixed-period": {
       "allowPeriodMarks": [":"],
     },

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "pretty-quick": "2.0.1",
     "rss": "1.2.2",
     "textlint-filter-rule-comments": "1.2.2",
+    "textlint-rule-preset-ja-spacing": "2.0.1",
     "typescript": "3.8.3"
   },
   "license": "MIT"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9188,6 +9188,14 @@ textlint-rule-helper@^2.0.0, textlint-rule-helper@^2.1.1:
     structured-source "^3.0.2"
     unist-util-visit "^1.1.0"
 
+textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/-/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana-2.0.1.tgz#ea6f94cb9ced758fb2553dea2e9fe714f31f0aed"
+  integrity sha1-6m+Uy5ztdY+yVT3qLp/nFPMfCu0=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
 textlint-rule-ja-no-abusage@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-abusage/-/textlint-rule-ja-no-abusage-2.0.1.tgz#cd07bea78a2dec65b4128f8d49e104d44f9084d9"
@@ -9217,6 +9225,23 @@ textlint-rule-ja-no-redundant-expression@^3.0.1:
     textlint-rule-helper "^2.1.1"
     textlint-util-to-string "^2.1.1"
 
+textlint-rule-ja-no-space-around-parentheses@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-space-around-parentheses/-/textlint-rule-ja-no-space-around-parentheses-2.0.1.tgz#556a60e679da9b4c98244c67e7961ac2e540bec1"
+  integrity sha1-VWpg5nnam0yYJExn55YawuVAvsE=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-no-space-between-full-width@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-space-between-full-width/-/textlint-rule-ja-no-space-between-full-width-2.0.1.tgz#921f78561564dd00c8733c230254acd8a55ded67"
+  integrity sha1-kh94VhVk3QDIczwjAlSs2KVd7Wc=
+  dependencies:
+    match-index "^1.0.1"
+    regx "^1.0.4"
+    textlint-rule-helper "^2.0.0"
+
 textlint-rule-ja-no-successive-word@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-successive-word/-/textlint-rule-ja-no-successive-word-1.1.0.tgz#243778076ce3f80d76bf2b9b73156c161e33c998"
@@ -9232,6 +9257,38 @@ textlint-rule-ja-no-weak-phrase@^1.0.4:
     kuromojin "^1.3.1"
     morpheme-match "^1.0.1"
     morpheme-match-all "^1.1.0"
+
+textlint-rule-ja-space-after-exclamation@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-after-exclamation/-/textlint-rule-ja-space-after-exclamation-2.0.1.tgz#3bc5d48c13269bd9cb1b18eb82e3d4eae44dfba3"
+  integrity sha1-O8XUjBMmm9nLGxjrguPU6uRN+6M=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-space-after-question@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-after-question/-/textlint-rule-ja-space-after-question-2.0.1.tgz#122260cb97d203768820276b4d09bf5270b11dfa"
+  integrity sha1-EiJgy5fSA3aIICdrTQm/UnCxHfo=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-space-around-code@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-2.0.1.tgz#6b7011dab69488f1eddd445554e7cddeaf1a90d3"
+  integrity sha1-a3AR2raUiPHt3URVVOfN3q8akNM=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-space-between-half-and-full-width@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-2.0.1.tgz#a527f83bd833149763e4043965f796c9ec2192ba"
+  integrity sha1-pSf4O9gzFJdj5AQ5ZfeWyewhkro=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
 
 textlint-rule-ja-unnatural-alphabet@2.0.1:
   version "2.0.1"
@@ -9346,6 +9403,19 @@ textlint-rule-no-nfd@^1.0.1:
     match-index "^1.0.3"
     textlint-rule-helper "^2.1.1"
     unorm "^1.4.1"
+
+textlint-rule-preset-ja-spacing@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-preset-ja-spacing/-/textlint-rule-preset-ja-spacing-2.0.1.tgz#4426e812b2fd525ed4c39d07ede2984ee9bf89d9"
+  integrity sha1-RCboErL9Ul7Uw50H7eKYTum/idk=
+  dependencies:
+    textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana "^2.0.1"
+    textlint-rule-ja-no-space-around-parentheses "^2.0.1"
+    textlint-rule-ja-no-space-between-full-width "^2.0.1"
+    textlint-rule-ja-space-after-exclamation "^2.0.1"
+    textlint-rule-ja-space-after-question "^2.0.1"
+    textlint-rule-ja-space-around-code "^2.0.1"
+    textlint-rule-ja-space-between-half-and-full-width "^2.0.1"
 
 textlint-rule-preset-ja-technical-writing@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## 変更内容
- precommit時に走るtextlintチェック前に自動修正を挟むようにした
- `textlint-rule-ja-space-between-half-and-full-width`: 半角文字と全角文字の間にスペースを入れるルールの追加
- `textlint-rule-ja-space-around-code`: インラインコードの周りにスペースを入れるルールの追加
- `pretty-quick --staged` をhusky側で実行させるようにした

<details>
<summary>その他プリセット経由で適応されるルール一覧</summary>

- `textlint-rule-ja-no-space-between-full-width`: 全角文字同士の間のスペースを入れない

- `textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana`: カタカナ語間の区切り文字についてはカタカナ語間は中黒または半角スペースを用いてカタカナ語を区切る

- `textlint-rule-ja-no-space-around-parentheses`: かっこの外側、内側ともにスペースを入れない

- `textlint-rule-ja-space-after-exclamation`: 文末に感嘆符を使用し、後に別の文が続く場合は、直後に全角スペースを挿入。 文中に感嘆符を使用する場合はスペースを挿入しない。

- `textlint-rule-ja-space-after-question`: 文末に疑問符を使用し、後に別の文が続く場合は、直後に全角スペースを挿入。 文中に疑問符を使用する場合はスペースを挿入しない。

</details>

## その理由について
- 上記ルールの導入によりfixableなerrorが多々起こり得るため自動修正挟んでからチェックする方が手間がかからなくなるため
- 日本語と english の間にスペースを入れるかどうかという表記揺れの問題が生じてしまっているので
- `pretty-quick` ではもともと husky とあわせて使うことが想定されているので
  - https://github.com/azz/pretty-quick#pre-commit-hook

## 備考
- [スタイルガイドの参考](https://github.com/gatsbyjs/gatsby-ja/blob/master/style-guide.md#%E5%8D%8A%E8%A7%92%E3%81%A8%E5%85%A8%E8%A7%92%E3%81%AE%E3%82%B9%E3%83%9A%E3%83%BC%E3%82%B9
)
- [textlintのスペース周りについての設定詳細](https://efcl.info/2016/07/21/textlint-rule-spacing/)
- その他適応されるルールについては現段階では問題なさそうだが、もし何か問題あれば適宜無効するなど対応していく
