### PR TITLE
Docs/api reference/next.config.js/runtime configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,26 @@
 
 ![reviewdog](https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs/workflows/reviewdog/badge.svg)
 
-Next.jsのドキュメントを翻訳する非公式プロジェクトです。
+Next.js のドキュメントを翻訳する非公式プロジェクトです。
 
 [本家公式ドキュメント](https://nextjs.org/docs/getting-started)
 
 ## 翻訳手順
 
-翻訳の状況は、[翻訳の概要と進捗状況](https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs/issues/3)のissuesを確認してください。
+翻訳の状況は、[翻訳の概要と進捗状況](https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs/issues/3)の issues を確認してください。
 
 ### 手順1:翻訳を始める準備
 
-まずは、このリポジトリを右上からForkしてください。
+まずは、このリポジトリを右上から Fork してください。
 
-そして、リポジトリをクローンします。`your`には、あなたのGitHubのユーザーネームを入れてください。
+そして、リポジトリをクローンします。`your`には、あなたの GitHub のユーザーネームを入れてください。
 
 ```
 $ git clone https://github.com/your/Nextjs-ja-translation-docs
 $ cd Nextjs-ja-translation-docs
 ```
 
-dependencyのインストールをしてください。必ず`yarn`で行ってください。
+dependency のインストールをしてください。必ず `yarn` で行ってください。
 
 ```
 $ yarn install
@@ -39,7 +39,7 @@ $ yarn install
 $ yarn dev
 ```
 
-翻訳作業を行うためのブランチを作成します。ここでは、例として`docs/example.md`を翻訳するためのブランチを作成します。
+翻訳作業を行うためのブランチを作成します。ここでは、例として `docs/example.md` を翻訳するためのブランチを作成します。
 
 ```
 $ git checkout -b docs/example
@@ -47,9 +47,9 @@ $ git checkout -b docs/example
 
 これで、翻訳を始める準備は完了です。エディタを使って、翻訳箇所のファイルを編集します。
 
-また、docs/manifest.jsonの各セクションのタイトルが設定されています。自分の担当箇所のタイトルを翻訳してください。
+また、docs/manifest.json の各セクションのタイトルが設定されています。自分の担当箇所のタイトルを翻訳してください。
 
-getting-staredを翻訳する例:
+getting-started を翻訳する例:
 
 ```
 { "title": "はじめに", "path": "/docs/getting-started.md" },
@@ -57,7 +57,7 @@ getting-staredを翻訳する例:
 
 ### 手順2:翻訳完了からプルリクエスト
 
-precommit時に翻訳の対象ファイルに対してtextlintが走ります。textlintが通らない限りcommitできません。エラーを修正する場合は、`text-lint:fix`を使います。
+precommit 時に翻訳の対象ファイルに対して textlint が走ります。textlint が通らない限り commit できません。エラーを修正する場合は、`text-lint:fix`を使います。
 
 ```
 $ yarn text-lint:fix ./docs/example.md
@@ -71,11 +71,11 @@ $ git commit -m "docs: translate docs/example.md"
 $ git push -u origin docs/example.md
 ```
 
-最後に、GitHub上からプルリクエストを作成してください。その後、メンテナーがレビューをして問題がなければマージされます。
+最後に、GitHub 上からプルリクエストを作成してください。その後、メンテナーがレビューをして問題がなければマージされます。
 
 ## Q&A
 
-質問がある場合は、[Slack](https://join.slack.com/t/nextjs-ja/shared_invite/zt-f9knbi69-AjTZqNZpYv7knG30jPwHcQ)に参加して、#questionsチャンネルまでお願いします。
+質問がある場合は、[Slack](https://join.slack.com/t/nextjs-ja/shared_invite/zt-f9knbi69-AjTZqNZpYv7knG30jPwHcQ)に参加して、#questions チャンネルまでお願いします。
 
 ## Contributors ✨
 

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -26,7 +26,7 @@ module.exports = {
 
 サーバー側だけで利用する値であれば、ランタイムの設定は `serverRuntimeConfig` に記述してください。
 
-クライアント側とサーバー側のどちらのコードからも使う値であれば、 `publicRuntimeConfig` に記述しましょう。
+クライアント側とサーバー側のどちらのコードからも使う値であれば、 `publicRuntimeConfig` に記述してください。
 
 > `publicRuntimeConfig` を使用しているページは [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) の対象から除外するために、 **必ず** `getInitialProps` を使ってください。 Runtime configuration は `getInitialProps` を使っていないページ（またはページ内のコンポーネント）では利用できません。
 

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -28,7 +28,7 @@ module.exports = {
 
 クライアント側とサーバー側のどちらのコードからも使う値であれば、 `publicRuntimeConfig` に記述してください。
 
-> `publicRuntimeConfig` を使用しているページは [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) の対象から除外するために、 **必ず** `getInitialProps` を使ってください。 Runtime configuration は `getInitialProps` を使っていないページ（またはページ内のコンポーネント）では利用できません。
+> `publicRuntimeConfig` に依存しているページは [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) の対象から除外するために、 **必ず** `getInitialProps` を使ってください。 ランタイム設定は `getInitialProps` を使っていないページ（またはページ内のコンポーネント）では利用できません。
 
 あなたのアプリケーションで Runtime config を利用するためには `next/config` を以下のように記述してください:
 

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -30,7 +30,7 @@ module.exports = {
 
 > `publicRuntimeConfig` に依存しているページは [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) の対象から除外するために、 **必ず** `getInitialProps` を使ってください。 ランタイム設定は `getInitialProps` を使っていないページ（またはページ内のコンポーネント）では利用できません。
 
-あなたのアプリケーションで Runtime config を利用するためには `next/config` を以下のように記述してください:
+アプリケーション内でランタイムの設定を利用するためには `next/config` を以下のように記述してください:
 
 ```jsx
 import getConfig from 'next/config';

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -1,5 +1,5 @@
 ---
-description: クライアント側とサーバー側のランタイムの設定をあなたの Next.js アプリケーションに追加します。
+description: クライアント側とサーバー側のランタイム設定を Next.js アプリケーションに追加します。
 ---
 
 # Runtime configuration

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -24,7 +24,7 @@ module.exports = {
 };
 ```
 
-サーバー側だけで利用する値であれば、 Runtime config は `serverRuntimeConfig` に記述します。
+サーバー側だけで利用する値であれば、ランタイムの設定は `serverRuntimeConfig` に記述してください。
 
 クライアント側とサーバー側のどちらのコードからも使う値であれば、 `publicRuntimeConfig` に記述しましょう。
 

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -2,7 +2,7 @@
 description: クライアント側とサーバー側のランタイム設定を Next.js アプリケーションに追加します。
 ---
 
-# Runtime configuration
+# ランタイム設定
 
 > 一般的には、 [環境変数](/docs/api-reference/next.config.js/environment-variables.md) を使用して設定を行うのがいいでしょう。なぜなら、ランタイム設定はレンダリング / 初期化時の余計な処理につながり、また [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) と互換性がないからです。
 

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -58,7 +58,7 @@ export default MyImage;
 <div class="card">
   <a href="/docs/api-reference/next.config.js/introduction.md">
     <b>next.config.js の紹介:</b>
-    <small>Next.js の設定ファイルについてもっと学ぶ。</small>
+    <small>Next.js の設定ファイルについて学ぶ。</small>
   </a>
 </div>
 

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -57,7 +57,7 @@ export default MyImage;
 
 <div class="card">
   <a href="/docs/api-reference/next.config.js/introduction.md">
-    <b>next.config.js の概要:</b>
+    <b>next.config.js の紹介:</b>
     <small>Next.js の設定ファイルについてもっと学ぶ。</small>
   </a>
 </div>

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -1,45 +1,45 @@
 ---
-description: Add client and server runtime configuration to your Next.js app.
+description: クライアント側とサーバー側のランタイムの設定をあなたの Next.js アプリケーションに追加します。
 ---
 
-# Runtime Configuration
+# Runtime configuration
 
-> Generally you'll want to use [build-time environment variables](/docs/api-reference/next.config.js/environment-variables.md) to provide your configuration. The reason for this is that runtime configuration adds rendering / initialization overhead and is incompatible with [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md).
+> 一般的に、あなたの Next.js アプリケーションに設定値を渡すためには [build-time environment variables](/docs/api-reference/next.config.js/environment-variables.md) を使いたいです。なぜなら、 Runtime configuration は レンダリング / 初期化 のオーバーヘッドにつながるからであり、また [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) は互換性がないからです。
 
-> Runtime configuration is not available when using the [`serverless` target](/docs/api-reference/next.config.js/build-target.md#serverless-target).
+> Runtime configuration は [`serverless` target](/docs/api-reference/next.config.js/build-target.md#serverless-target) のときは利用できません。
 
-To add runtime configuration to your app open `next.config.js` and add the `publicRuntimeConfig` and `serverRuntimeConfig` configs:
+Runtime configuration をあなたのアプリケーションに追加するためには、 `next.config.js` に `publicRuntimeConfig` と `serverRuntimeConfig` を記述してください:
 
 ```js
 module.exports = {
   serverRuntimeConfig: {
-    // Will only be available on the server side
+    // サーバー側でのみ使えます
     mySecret: 'secret',
-    secondSecret: process.env.SECOND_SECRET // Pass through env variables
+    secondSecret: process.env.SECOND_SECRET // 環境変数から渡す
   },
   publicRuntimeConfig: {
-    // Will be available on both server and client
+    // サーバー側、クライアント側の両方で使えます
     staticFolder: '/static'
   }
 };
 ```
 
-Place any server-only runtime config under `serverRuntimeConfig`.
+サーバー側だけで利用する値であれば、 Runtime config は `serverRuntimeConfig` に記述します。
 
-Anything accessible to both client and server-side code should be under `publicRuntimeConfig`.
+クライアント側とサーバー側のどちらのコードからも使う値であれば、 `publicRuntimeConfig` に記述しましょう。
 
-> A page that relies on `publicRuntimeConfig` **must** use `getInitialProps` to opt-out of [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md). Runtime configuration won't be available to any page (or component in a page) without `getInitialProps`.
+> `publicRuntimeConfig` を使用しているページは [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) の対象から除外するために、 **必ず** `getInitialProps` を使ってください。 Runtime configuration は `getInitialProps` を使っていないページ（またはページ内のコンポーネント）では利用できません。
 
-To get access to the runtime configs in your app use `next/config`, like so:
+あなたのアプリケーションで Runtime config を利用するためには `next/config` を以下のように記述してください:
 
 ```jsx
 import getConfig from 'next/config';
 
-// Only holds serverRuntimeConfig and publicRuntimeConfig
+// serverRuntimeConfig と publicRuntimeConfig だけを保持している
 const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
-// Will only be available on the server-side
+// サーバー側でのみ使えます
 console.log(serverRuntimeConfig.mySecret);
-// Will be available on both server-side and client-side
+// サーバー側、クライアント側の両方で使えます
 console.log(publicRuntimeConfig.staticFolder);
 
 function MyImage() {
@@ -53,18 +53,18 @@ function MyImage() {
 export default MyImage;
 ```
 
-## Related
+## 関連事項
 
 <div class="card">
   <a href="/docs/api-reference/next.config.js/introduction.md">
-    <b>Introduction to next.config.js:</b>
-    <small>Learn more about the configuration file used by Next.js.</small>
+    <b>next.config.js の概要:</b>
+    <small>Next.js の設定ファイルについてもっと学ぶ。</small>
   </a>
 </div>
 
 <div class="card">
   <a href="/docs/api-reference/next.config.js/environment-variables.md">
-    <b>Environment Variables:</b>
-    <small>Access environment variables in your Next.js application at build time.</small>
+    <b>環境変数:</b>
+    <small>あなたの Next.js アプリケーションのビルド時に環境変数を利用する。</small>
   </a>
 </div>

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -8,7 +8,7 @@ description: クライアント側とサーバー側のランタイム設定を 
 
 > ランタイム設定は [`serverless` target](/docs/api-reference/next.config.js/build-target.md#serverless-target) のときは利用できません。
 
-Runtime configuration をあなたのアプリケーションに追加するためには、 `next.config.js` に `publicRuntimeConfig` と `serverRuntimeConfig` を記述してください:
+ランタイム設定を追加するためには、`next.config.js` に `publicRuntimeConfig` と `serverRuntimeConfig` を記述してください:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -65,6 +65,6 @@ export default MyImage;
 <div class="card">
   <a href="/docs/api-reference/next.config.js/environment-variables.md">
     <b>環境変数:</b>
-    <small>あなたの Next.js アプリケーションのビルド時に環境変数を利用する。</small>
+    <small>Next.js アプリケーションのビルド時に環境変数を利用する。</small>
   </a>
 </div>

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -4,7 +4,7 @@ description: クライアント側とサーバー側のランタイムの設定�
 
 # Runtime configuration
 
-> 一般的に、あなたの Next.js アプリケーションに設定値を渡すためには [build-time environment variables](/docs/api-reference/next.config.js/environment-variables.md) を使いたいです。なぜなら、 Runtime configuration は レンダリング / 初期化 のオーバーヘッドにつながるからであり、また [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) は互換性がないからです。
+> 一般的には、 [環境変数](/docs/api-reference/next.config.js/environment-variables.md) を使用して設定を行うのがいいでしょう。なぜなら、ランタイム設定はレンダリング / 初期化時の余計な処理につながり、また [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) と互換性がないからです。
 
 > Runtime configuration は [`serverless` target](/docs/api-reference/next.config.js/build-target.md#serverless-target) のときは利用できません。
 

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -6,7 +6,7 @@ description: クライアント側とサーバー側のランタイム設定を 
 
 > 一般的には、 [環境変数](/docs/api-reference/next.config.js/environment-variables.md) を使用して設定を行うのがいいでしょう。なぜなら、ランタイム設定はレンダリング / 初期化時の余計な処理につながり、また [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) と互換性がないからです。
 
-> Runtime configuration は [`serverless` target](/docs/api-reference/next.config.js/build-target.md#serverless-target) のときは利用できません。
+> ランタイム設定は [`serverless` target](/docs/api-reference/next.config.js/build-target.md#serverless-target) のときは利用できません。
 
 Runtime configuration をあなたのアプリケーションに追加するためには、 `next.config.js` に `publicRuntimeConfig` と `serverRuntimeConfig` を記述してください:
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -240,7 +240,7 @@
               "path": "/docs/api-reference/next.config.js/static-optimization-indicator.md"
             },
             {
-              "title": "Runtime Configuration",
+              "title": "ランタイムの設定",
               "path": "/docs/api-reference/next.config.js/runtime-configuration.md"
             },
             {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -240,7 +240,7 @@
               "path": "/docs/api-reference/next.config.js/static-optimization-indicator.md"
             },
             {
-              "title": "ランタイムの設定",
+              "title": "ランタイム設定",
               "path": "/docs/api-reference/next.config.js/runtime-configuration.md"
             },
             {


### PR DESCRIPTION
`docs/api-reference/next.config.js/runtime-configuration.md`を翻訳しました。

- 原文を忠実に翻訳するよりは、原語に添いながらも意図を汲んで日本語として読みやすい訳を心がけました。
- 文中の `Runtime Configuration`  `Runtime Config`  を「ランタイムの設定」と訳すか迷いましたが、「ランタイムの設定」では意味がわかりにくいことと、`Runtime Configuration` という機能名であると考えて、原語のままにしました。

レビューのほどよろしくお願いします。