### PR TITLE
fix: token variable name

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,18 +11,21 @@ jobs:
       - name: textlint-github-pr-check
         uses: tsuyoshicho/action-textlint@master
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.REVIEWDOG_GITHUB_TOKEN }}
           reporter: github-pr-check
           textlint_flags: 'docs/**'
+          level: error
       - name: textlint-github-check
         uses: tsuyoshicho/action-textlint@master
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.REVIEWDOG_GITHUB_TOKEN }}
           reporter: github-check
           textlint_flags: 'docs/**'
+          level: error
       - name: textlint-github-pr-review
         uses: tsuyoshicho/action-textlint@master
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.REVIEWDOG_GITHUB_TOKEN }}
           reporter: github-pr-review
           textlint_flags: 'docs/**'
+          level: error

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,21 +11,21 @@ jobs:
       - name: textlint-github-pr-check
         uses: tsuyoshicho/action-textlint@master
         with:
-          github_token: ${{ secrets.REVIEWDOG_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
           textlint_flags: 'docs/**'
           level: error
       - name: textlint-github-check
         uses: tsuyoshicho/action-textlint@master
         with:
-          github_token: ${{ secrets.REVIEWDOG_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
           textlint_flags: 'docs/**'
           level: error
       - name: textlint-github-pr-review
         uses: tsuyoshicho/action-textlint@master
         with:
-          github_token: ${{ secrets.REVIEWDOG_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           textlint_flags: 'docs/**'
           level: error

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,9 +4,9 @@ description: 公式ドキュメントでNext.jsを始めてみましょう！
 
 # はじめに
 
-Next.js のドキュメントへようこそ！
+Next.jsのドキュメントへようこそ！
 
-Next.js を初めて使用する場合は、[学習コース](https://nextjs.org/learn/basics/getting-started)から始めることをお勧めします。
+Next.jsを初めて使用する場合は、[学習コース](https://nextjs.org/learn/basics/getting-started)から始めることをお勧めします。
 
 `学習コースは翻訳されていません。`
 


### PR DESCRIPTION
reviewdogに渡すtokenの変数名をfixしました.

fork元のブランチによるPRでもreviewdogがwrite権限を持っているかテストするために, このPRでわざと怒られを発生させます