### PR TITLE
chore(lint): ignore no-doubled-joshi rule for only 'か'

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -4,6 +4,10 @@
       "no-exclamation-question-mark": {
         "allowFullWidthExclamation": true,
         "allowFullWidthQuestion": true,
+      },
+      "no-doubled-joshi": {
+         "strict": false,
+         "allow": ["か"], // 助詞のうち「か」は複数回の出現を許す(e.g.: するかどうか)
       }
     },
     "preset-ja-spacing": {


### PR DESCRIPTION
## 変更内容
- 助詞の重複をチェックするルールで「か」は適用外とした

## 変更理由
- 「〜するかどうか」といった日本語訳ができないため
- 助詞の「か」が複数回出るケースは少ないと思うので

cf: https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs/pull/123#discussion_r460597905