### PR TITLE
docs(style-guide): add translation of 'document'

### DIFF
--- a/styleguide.md
+++ b/styleguide.md
@@ -129,8 +129,9 @@ Next.jsでは`export`された[React コンポーネント](https://reactjs.org/
 | Import           | インポート                 |
 | Export           | エクスポート               |
 | warnings         | 警告                       |
-| introduce to     | の紹介                     |
+| introduce to xx  | xx の紹介                  |
 | learn more about | について詳しく学びましょう |
+| xx documentation | xx のドキュメント          |
 
 ### 原文のままの方がいいと判断された用語
 


### PR DESCRIPTION
ref: https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs/pull/134#discussion_r461621396

## 変更内容
- `xx documentation` の訳として「xx のドキュメント」とした

## 変更理由
- `xx documentation` は頻出で表記ゆれうるので