### PR TITLE
fix: multi-zone example link

### DIFF
--- a/docs/advanced-features/multi-zones.md
+++ b/docs/advanced-features/multi-zones.md
@@ -3,7 +3,7 @@
 <details>
   <summary><b>例</b></summary>
   <ul>
-    <li><a href="/examples/with-zones">マルチゾーン</a></li>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-zones">マルチゾーン</a></li>
   </ul>
 </details>
 


### PR DESCRIPTION
close #145 
リンク先が404だったので修正
- `https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs/master/blob/canary/examples/with-zones` -> `https://github.com/vercel/next.js/tree/canary/examples/with-zones`