### PR TITLE
fix contributors link.

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -70,7 +70,7 @@ export default withPure(() => (
               </Link>
             </p>
             <p>
-              <Link href="/contributors">
+              <Link href="https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs#contributors-">
                 <a>コントリビューター</a>
               </Link>
             </p>

--- a/components/home/intro.js
+++ b/components/home/intro.js
@@ -137,7 +137,7 @@ export default class extends React.PureComponent {
                 </div>
 
                 <div className="button-spacer">
-                  <Button href="/contributors" invert outline>
+                  <Button href="https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs#contributors-" invert outline>
                     コントリビューター
                   </Button>
                 </div>


### PR DESCRIPTION
トップページの「コントリビューター」ボタンとfooterの「コントリビューター」リンク先（ `/contributors` ）が404でした。

おそらくこちら↓のコントリビューターリストを意図しているのではないかと思い、PR送りました 🙏 

https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs#contributors-

もし意図と違いましたらご教示くださいませ。

I hope all great contributors get well recognized by the community 😃 