### PR TITLE
docs: updated the title of custom-page-extensions at left menus

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -216,7 +216,7 @@
               "path": "/docs/api-reference/next.config.js/environment-variables.md"
             },
             {
-              "title": "Custom Page Extensions",
+              "title": "独自のページ拡張子",
               "path": "/docs/api-reference/next.config.js/custom-page-extensions.md"
             },
             {


### PR DESCRIPTION
`docs/manifest.json` で一箇所更新されていなかったので更新しましたー。