### PR TITLE
docs: update (2020-10-19)

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -31,6 +31,9 @@
     }
   },
   "filters": {
-    "comments": true
+    "comments": {
+      "disablingComment": "textlint-disable", // textlint のチェック対象から外す
+      "enablingComment": "textlint-enable", // textlint のチェックを再開
+    }
   }
 }

--- a/docs/advanced-features/codemods.md
+++ b/docs/advanced-features/codemods.md
@@ -1,0 +1,149 @@
+---
+description: Use codemods to update your codebase when upgrading Next.js to the latest version
+---
+
+# Next.js Codemods
+
+Next.js provides Codemod transformations to help upgrade your Next.js codebase when a feature is deprecated.
+
+Codemods are transformations that run on your codebase programmatically. This allows for a large amount of changes to be applied without having to manually go through every file.
+
+## Usage
+
+`npx @next/codemod <transform> <path>`
+
+- `transform` - name of transform, see available transforms below.
+- `path` - files or directory to transform
+- `--dry` Do a dry-run, no code will be edited
+- `--print` Prints the changed output for comparison
+
+## Next.js 9
+
+### `name-default-component`
+
+Transforms anonymous components into named components to make sure they work with [Fast Refresh](https://nextjs.org/blog/next-9-4#fast-refresh).
+
+For example
+
+```jsx
+// my-component.js
+export default function () {
+  return <div>Hello World</div>
+}
+```
+
+Transforms into:
+
+```jsx
+// my-component.js
+export default function MyComponent() {
+  return <div>Hello World</div>
+}
+```
+
+The component will have a camel cased name based on the name of the file, and it also works with arrow functions.
+
+#### Usage
+
+Go to your project
+
+```
+cd path-to-your-project/
+```
+
+Run the codemod:
+
+```
+npx @next/codemod name-default-component
+```
+
+### `withamp-to-config`
+
+Transforms the `withAmp` HOC into Next.js 9 page configuration.
+
+For example:
+
+```js
+// Before
+import { withAmp } from 'next/amp'
+
+function Home() {
+  return <h1>My AMP Page</h1>
+}
+
+export default withAmp(Home)
+```
+
+```js
+// After
+export default function Home() {
+  return <h1>My AMP Page</h1>
+}
+
+export const config = {
+  amp: true,
+}
+```
+
+#### Usage
+
+Go to your project
+
+```
+cd path-to-your-project/
+```
+
+Run the codemod:
+
+```
+npx @next/codemod withamp-to-config
+```
+
+## Next.js 6
+
+### `url-to-withrouter`
+
+Transforms the deprecated automatically injected `url` property on top level pages to using `withRouter` and the `router` property it injects. Read more here: [err.sh/next.js/url-deprecated](https://err.sh/next.js/url-deprecated)
+
+For example:
+
+```js
+// From
+import React from 'react'
+export default class extends React.Component {
+  render() {
+    const { pathname } = this.props.url
+    return <div>Current pathname: {pathname}</div>
+  }
+}
+```
+
+```js
+// To
+import React from 'react'
+import { withRouter } from 'next/router'
+export default withRouter(
+  class extends React.Component {
+    render() {
+      const { pathname } = this.props.router
+      return <div>Current pathname: {pathname}</div>
+    }
+  }
+)
+```
+
+This is just one case. All the cases that are transformed (and tested) can be found in the [`__testfixtures__` directory](./transforms/__testfixtures__/url-to-withrouter).
+
+#### Usage
+
+Go to your project
+
+```
+cd path-to-your-project/
+```
+
+Run the codemod:
+
+```
+npx @next/codemod url-to-withrouter
+```

--- a/docs/advanced-features/debugging.md
+++ b/docs/advanced-features/debugging.md
@@ -1,0 +1,77 @@
+---
+description: Debug your Next.js app.
+---
+
+# Debugging
+
+This documentation explains how you can debug your Next.js frontend and backend code with full source maps support using either the [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools) or the [VSCode debugger](https://code.visualstudio.com/docs/editor/debugging).
+
+It requires you to first launch your Next.js application in debug mode in one terminal and then connect an inspector (Chrome DevTools or VS Code) to it.
+
+There might be more ways to debug a Next.js application since all it requires is to expose the Node.js debugger and start an inspector client. You can find more details in the [Node.js documentation](https://nodejs.org/en/docs/guides/debugging-getting-started/).
+
+## Step 1: Start Next.js in debug mode
+
+Next.js being a Node.js application, all we have to do is to pass down the [`--inspect`](https://nodejs.org/api/cli.html#cli_node_options_options) flag to the underlying Node.js process for it to start in debug mode.
+
+First, start Next.js with the inspect flag:
+
+```bash
+NODE_OPTIONS='--inspect' next dev
+```
+
+If you're using `npm run dev` or `yarn dev` (See: [Getting Started](/docs/getting-started.md)) then you should update the `dev` script on your `package.json`:
+
+```json
+"dev": "NODE_OPTIONS='--inspect' next dev"
+```
+
+The result of launching Next.js with the inspect flag looks like this:
+
+```bash
+Debugger listening on ws://127.0.0.1:9229/0cf90313-350d-4466-a748-cd60f4e47c95
+For help, see: https://nodejs.org/en/docs/inspector
+ready - started server on http://localhost:3000
+```
+
+> Be aware that using `NODE_OPTIONS='--inspect' npm run dev` or `NODE_OPTIONS='--inspect' yarn dev` won't work. This would try to start multiple debuggers on the same port: one for the npm/yarn process and one for Next.js. You would then get an error like `Starting inspector on 127.0.0.1:9229 failed: address already in use` in your console.
+
+## Step 2: Connect to the debugger
+
+### Using Chrome DevTools
+
+Once you open a new tab in Google Chrome and go to `chrome://inspect`, you should see your Next.js application inside the "Remote Target" section. Now click "inspect" to open a screen that will be your debugging environment from now on.
+
+### Using the Debugger in Visual Studio Code
+
+We will be using the [attach mode](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_setting-up-an-attach-configuration) of VS Code to attach the VS Code inspector to our running debugger started in step 1.
+
+Create a file named `.vscode/launch.json` at the root of your project with this content:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Launch Program",
+      "skipFiles": ["<node_internals>/**"],
+      "port": 9229
+    }
+  ]
+}
+```
+
+Now hit <kdb>F5</kbd> or select **Debug: Start Debugging** from the Command Palette and you can start your debugging session.
+
+## Step 3: Put breakpoints and see what happens
+
+Now you can use the [`debugger`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger) statement to pause your backend or frontend code anytime you want to observe and debug your code more precisely.
+
+If you trigger the underlying code by refreshing the current page, clicking on a page link or fetching an API route, your code will be paused and the debugger window will pop up.
+
+To learn more on how to use a JavaScript debugger, take a look at the following documentation:
+
+- [VS Code Node.js debugging: Breakpoints](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_breakpoints)
+- [Get Started with Debugging JavaScript in Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/javascript)

--- a/docs/api-reference/create-next-app.md
+++ b/docs/api-reference/create-next-app.md
@@ -1,0 +1,57 @@
+---
+description: Create Next.js apps in one command with create-next-app.
+---
+
+# Create Next App
+
+The easiest way to get started with Next.js is by using `create-next-app`. This simple CLI tool enables you to quickly start building a new Next.js application, with everything set up for you. You can create a new app using the default Next.js template, or by using one of the [official Next.js examples](https://github.com/vercel/next.js/tree/canary/examples). To get started, use the following command:
+
+```bash
+npx create-next-app
+# or
+yarn create next-app
+```
+
+### Options
+
+`create-next-app` comes with the following options:
+
+- **-e, --example [name]|[github-url]** - An example to bootstrap the app with. You can use an example name from the [Next.js repo](https://github.com/vercel/next.js/tree/master/examples) or a GitHub URL. The URL can use any branch and/or subdirectory.
+- **--example-path [path-to-example]** - In a rare case, your GitHub URL might contain a branch name with a slash (e.g. bug/fix-1) and the path to the example (e.g. foo/bar). In this case, you must specify the path to the example separately: `--example-path foo/bar`
+
+<!-- textlint-disable ja-technical-writing/no-exclamation-question-mark -->
+### Why use Create Next App?
+<!-- textlint-enable ja-technical-writing/no-exclamation-question-mark -->
+
+`create-next-app` allows you to create a new Next.js app within seconds. It is officially maintained by the creators of Next.js, and includes a number of benefits:
+
+- **Interactive Experience**: Running `npx create-next-app` (with no arguments) launches an interactive experience that guides you through setting up a project.
+- **Zero Dependencies**: Initializing a project is as quick as one second. Create Next App has zero dependencies.
+- **Offline Support**: Create Next App will automatically detect if you're offline and bootstrap your project using your local package cache.
+- **Support for Examples**: Create Next App can bootstrap your application using an example from the Next.js examples collection (e.g. `npx create-next-app --example api-routes`).
+- **Tested**: The package is part of the Next.js monorepo and tested using the same integration test suite as Next.js itself, ensuring it works as expected with every release.
+
+## Related
+
+For more information on what to do next, we recommend the following sections:
+
+<div class="card">
+  <a href="/docs/basic-features/pages.md">
+    <b>Pages:</b>
+    <small>Learn more about what pages are in Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/built-in-css-support.md">
+    <b>CSS Support:</b>
+    <small>Use the built-in CSS support to add custom styles to your app.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/api-reference/cli.md">
+    <b>CLI:</b>
+    <small>Learn more about the Next.js CLI.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/basepath.md
+++ b/docs/api-reference/next.config.js/basepath.md
@@ -1,0 +1,43 @@
+---
+description: Learn more about setting a base path in Next.js
+---
+
+# Base Path
+
+> This feature was introduced in [Next.js 9.5](https://nextjs.org/blog/next-9-5) and up. If you’re using older versions of Next.js, please upgrade before trying it out.
+
+To deploy a Next.js application under a sub-path of a domain you can use the `basePath` config option.
+
+`basePath` allows you to set a path prefix for the application. For example, to use `/docs` instead of `/` (the default), open `next.config.js` and add the `basePath` config:
+
+```js
+module.exports = {
+  basePath: '/docs',
+}
+```
+
+## Links
+
+When linking to other pages using `next/link` and `next/router` the `basePath` will be automatically applied.
+
+For example using `/about` will automatically become `/docs/about` when `basePath` is set to `/docs`.
+
+```js
+export default function HomePage() {
+  return (
+    <>
+      <Link href="/about">
+        <a>About Page</a>
+      </Link>
+    </>
+  )
+}
+```
+
+Output html:
+
+```html
+<a href="/docs/about">About Page</a>
+```
+
+This makes sure that you don't have to change all links in your application when changing the `basePath` value.

--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -1,0 +1,177 @@
+---
+description: Add custom HTTP headers to your Next.js app.
+---
+
+# Headers
+
+> This feature was introduced in [Next.js 9.5](https://nextjs.org/blog/next-9-5) and up. If you’re using older versions of Next.js, please upgrade before trying it out.
+
+Headers allow you to set custom HTTP headers for an incoming request path.
+
+To set custom HTTP headers you can use the `headers` key in `next.config.js`:
+
+```js
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/about',
+        headers: [
+          {
+            key: 'x-custom-header',
+            value: 'my custom header value',
+          },
+          {
+            key: 'x-another-custom-header',
+            value: 'my other custom header value',
+          },
+        ],
+      },
+    ]
+  },
+}
+```
+
+`headers` is an async function that expects an array to be returned holding objects with `source` and `headers` properties:
+
+- `source` is the incoming request path pattern.
+- `headers` is an array of header objects with the `key` and `value` properties.
+
+## Header Overriding Behavior
+
+If two headers match the same path and set the same header key, the last header key will override the first. Using the below headers, the path `/hello` will result in the header `x-hello` being `world` due to the last header value set being `world`.
+
+```js
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'there',
+          },
+        ],
+      },
+      {
+        source: '/hello',
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world',
+          },
+        ],
+      },
+    ],
+  },
+}
+```
+
+## Path Matching
+
+Path matches are allowed, for example `/blog/:slug` will match `/blog/hello-world` (no nested paths):
+
+```js
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/blog/:slug',
+        headers: [
+          {
+            key: 'x-slug',
+            value: ':slug', // Matched parameters can be used in the value
+          },
+          {
+            key: 'x-slug-:slug', // Matched parameters can be used in the key
+            value: 'my other custom header value',
+          },
+        ],
+      },
+    ],
+  },
+}
+```
+
+### Wildcard Path Matching
+
+To match a wildcard path you can use `*` after a parameter, for example `/blog/:slug*` will match `/blog/a/b/c/d/hello-world`:
+
+```js
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/blog/:slug*',
+        headers: [
+          {
+            key: 'x-slug',
+            value: ':slug*', // Matched parameters can be used in the value
+          },
+          {
+            key: 'x-slug-:slug*', // Matched parameters can be used in the key
+            value: 'my other custom header value',
+          },
+        ],
+      },
+    ],
+  },
+}
+```
+
+### Regex Path Matching
+
+To match a regex path you can wrap the regex in parenthesis after a parameter, for example `/blog/:slug(\\d{1,})` will match `/blog/123` but not `/blog/abc`:
+
+```js
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/blog/:post(\\d{1,})',
+        headers: [
+          {
+            key: 'x-post',
+            value: ':post',
+          },
+        ],
+      },
+    ],
+  },
+}
+```
+
+### Headers with basePath support
+
+When leveraging [`basePath` support](/docs/api-reference/next.config.js/basepath.md) with headers each `source` is automatically prefixed with the `basePath` unless you add `basePath: false` to the header:
+
+```js
+module.exports = {
+  basePath: '/docs',
+
+  async headers() {
+    return [
+      {
+        source: '/with-basePath', // becomes /docs/with-basePath
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world',
+          },
+        ],
+      },
+      {
+        source: '/without-basePath', // is not modified since basePath: false is set
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world',
+          },
+        ],
+        basePath: false,
+      },
+    ]
+  },
+}
+```

--- a/docs/api-reference/next.config.js/react-strict-mode.md
+++ b/docs/api-reference/next.config.js/react-strict-mode.md
@@ -1,0 +1,31 @@
+---
+description: The complete Next.js runtime is now Strict Mode-compliant, learn how to opt-in
+---
+
+# React Strict Mode
+
+> **Suggested**: We strongly suggest you enable Strict Mode in your Next.js application to better prepare your application for the future of React.
+
+The Next.js runtime is now Strict Mode-compliant. To opt-in to Strict Mode, configure the following option in your `next.config.js`:
+
+```js
+// next.config.js
+module.exports = {
+  reactStrictMode: true,
+}
+```
+
+<!-- textlint-disable ja-technical-writing/no-exclamation-question-mark -->
+If you or your team are not ready to use Strict Mode in your entire application, that's OK! You can incrementally migrate on a page-by-page basis [using `<React.StrictMode>`](https://reactjs.org/docs/strict-mode.html).
+<!-- textlint-enable ja-technical-writing/no-exclamation-question-mark -->
+
+React's Strict Mode is a development mode only feature for highlighting potential problems in an application. It helps to identify unsafe lifecycles, legacy API usage, and a number of other features.
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -1,0 +1,123 @@
+---
+description: Add redirects to your Next.js app.
+---
+
+# Redirects
+
+> This feature was introduced in [Next.js 9.5](https://nextjs.org/blog/next-9-5) and up. If you’re using older versions of Next.js, please upgrade before trying it out.
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/redirects">Redirects</a></li>
+  </ul>
+</details>
+
+Redirects allow you to redirect an incoming request path to a different destination path.
+
+Redirects are only available on the Node.js environment and do not affect client-side routing.
+
+To use Redirects you can use the `redirects` key in `next.config.js`:
+
+```js
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/about',
+        destination: '/',
+        permanent: true,
+      },
+    ]
+  },
+}
+```
+
+`redirects` is an async function that expects an array to be returned holding objects with `source`, `destination`, and `permanent` properties:
+
+- `source` is the incoming request path pattern.
+- `destination` is the path you want to route to.
+- `permanent` if the redirect is permanent or not.
+
+## Path Matching
+
+Path matches are allowed, for example `/old-blog/:slug` will match `/old-blog/hello-world` (no nested paths):
+
+```js
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/old-blog/:slug',
+        destination: '/news/:slug', // Matched parameters can be used in the destination
+        permanent: true,
+      },
+    ]
+  },
+}
+```
+
+### Wildcard Path Matching
+
+To match a wildcard path you can use `*` after a parameter, for example `/blog/:slug*` will match `/blog/a/b/c/d/hello-world`:
+
+```js
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/blog/:slug*',
+        destination: '/news/:slug*', // Matched parameters can be used in the destination
+        permanent: true,
+      },
+    ]
+  },
+}
+```
+
+### Regex Path Matching
+
+To match a regex path you can wrap the regex in parenthesis after a parameter, for example `/blog/:slug(\\d{1,})` will match `/blog/123` but not `/blog/abc`:
+
+```js
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/old-blog/:post(\\d{1,})',
+        destination: '/blog/:post', // Matched parameters can be used in the destination
+        permanent: false,
+      },
+    ]
+  },
+}
+```
+
+### Redirects with basePath support
+
+When leveraging [`basePath` support](/docs/api-reference/next.config.js/basepath.md) with redirects each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the redirect:
+
+```js
+module.exports = {
+  basePath: '/docs',
+
+  async redirects() {
+    return [
+      {
+        source: '/with-basePath', // automatically becomes /docs/with-basePath
+        destination: '/another', // automatically becomes /docs/another
+        permanent: false,
+      },
+      {
+        // does not add /docs since basePath: false is set
+        source: '/without-basePath',
+        destination: '/another',
+        basePath: false,
+        permanent: false,
+      },
+    ]
+  },
+}
+```
+
+In some rare cases, you might need to assign a custom status code for older HTTP Clients to properly redirect. In these cases, you can use the `statusCode` property instead of the `permanent` property, but not both. Note: to ensure IE11 compatibility a `Refresh` header is automatically added for the 308 status code.

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -1,0 +1,165 @@
+---
+description: Add rewrites to your Next.js app.
+---
+
+# Rewrites
+
+> This feature was introduced in [Next.js 9.5](https://nextjs.org/blog/next-9-5) and up. If you’re using older versions of Next.js, please upgrade before trying it out.
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/rewrites">Rewrites</a></li>
+  </ul>
+</details>
+
+Rewrites allow you to map an incoming request path to a different destination path.
+
+Rewrites are only available on the Node.js environment and do not affect client-side routing.
+
+Rewrites are not able to override public files or routes in the pages directory as these have higher priority than rewrites. For example, if you have `pages/index.js` you are not able to rewrite `/` to another location unless you rename the `pages/index.js` file.
+
+To use rewrites you can use the `rewrites` key in `next.config.js`:
+
+```js
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/about',
+        destination: '/',
+      },
+    ]
+  },
+}
+```
+
+`rewrites` is an async function that expects an array to be returned holding objects with `source` and `destination` properties:
+
+- `source` is the incoming request path pattern.
+- `destination` is the path you want to route to.
+
+## Path Matching
+
+Path matches are allowed, for example `/blog/:slug` will match `/blog/hello-world` (no nested paths):
+
+```js
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/blog/:slug',
+        destination: '/news/:slug', // Matched parameters can be used in the destination
+      },
+    ]
+  },
+}
+```
+
+### Wildcard Path Matching
+
+To match a wildcard path you can use `*` after a parameter, for example `/blog/:slug*` will match `/blog/a/b/c/d/hello-world`:
+
+```js
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/blog/:slug*',
+        destination: '/news/:slug*', // Matched parameters can be used in the destination
+      },
+    ]
+  },
+}
+```
+
+### Regex Path Matching
+
+To match a regex path you can wrap the regex in parenthesis after a parameter, for example `/blog/:slug(\\d{1,})` will match `/blog/123` but not `/blog/abc`:
+
+```js
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/old-blog/:post(\\d{1,})',
+        destination: '/blog/:post', // Matched parameters can be used in the destination
+      },
+    ]
+  },
+}
+```
+
+## Rewriting to an external URL
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/custom-routes-proxying">Incremental adoption of Next.js</a></li>
+  </ul>
+</details>
+
+Rewrites allow you to rewrite to an external url. This is especially useful for incrementally adopting Next.js.
+
+```js
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/blog/:slug',
+        destination: 'https://example.com/blog/:slug', // Matched parameters can be used in the destination
+      },
+    ]
+  },
+}
+```
+
+### Incremental adoption of Next.js
+
+You can also make Next.js check the application routes before falling back to proxying to the previous website.
+
+This way you don't have to change the rewrites configuration when migrating more pages to Next.js
+
+```js
+module.exports = {
+  async rewrites() {
+    return [
+      // we need to define a no-op rewrite to trigger checking
+      // all pages/static files before we attempt proxying
+      {
+        source: '/:path*',
+        destination: '/:path*',
+      },
+      {
+        source: '/:path*',
+        destination: `https://custom-routes-proxying-endpoint.vercel.app/:path*`,
+      },
+    ]
+  },
+}
+```
+
+### Rewrites with basePath support
+
+When leveraging [`basePath` support](/docs/api-reference/next.config.js/basepath.md) with rewrites each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the rewrite:
+
+```js
+module.exports = {
+  basePath: '/docs',
+
+  async rewrites() {
+    return [
+      {
+        source: '/with-basePath', // automatically becomes /docs/with-basePath
+        destination: '/another', // automatically becomes /docs/another
+      },
+      {
+        // does not add /docs since basePath: false is set
+        source: '/without-basePath',
+        destination: '/another',
+        basePath: false,
+      },
+    ]
+  },
+}
+```

--- a/docs/api-reference/next.config.js/trailing-slash.md
+++ b/docs/api-reference/next.config.js/trailing-slash.md
@@ -1,0 +1,28 @@
+---
+description: Configure Next.js pages to resolve with or without a trailing slash.
+---
+
+# Trailing Slash
+
+> This feature was introduced in [Next.js 9.5](https://nextjs.org/blog/next-9-5) and up. If you’re using older versions of Next.js, please upgrade before trying it out.
+
+By default Next.js will redirect urls with trailing slashes to their counterpart without a trailing slash. For example `/about/` will redirect to `/about`. You can configure this behavior to act the opposite way, where urls without trailing slashes are redirected to their counterparts with trailing slashes.
+
+Open `next.config.js` and add the `trailingSlash` config:
+
+```js
+module.exports = {
+  trailingSlash: true,
+}
+```
+
+With this option set, urls like `/about` will redirect to `/about/`.
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/basic-features/fast-refresh.md
+++ b/docs/basic-features/fast-refresh.md
@@ -1,0 +1,123 @@
+---
+description:
+  Next.js' Fast Refresh is a new hot reloading experience that gives you
+  instantaneous feedback on edits made to your React components.
+---
+
+# Fast Refresh
+
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/fast-refresh-demo">Fast Refresh Demo</a></li>
+  </ul>
+</details>
+
+Fast Refresh is a Next.js feature that gives you instantaneous feedback on
+edits made to your React components. Fast Refresh is enabled by default in all
+Next.js applications on **9.4 or newer**. With Next.js Fast Refresh enabled,
+most edits should be visible within a second, **without losing component
+state**.
+
+## How It Works
+
+<!-- textlint-disable ja-technical-writing/max-comma -->
+- If you edit a file that **only exports React component(s)**, Fast Refresh will
+  update the code only for that file, and re-render your component. You can edit
+  anything in that file, including styles, rendering logic, event handlers, or
+  effects.
+- If you edit a file with exports that _aren't_ React components, Fast Refresh
+  will re-run both that file, and the other files importing it. So if both
+  `Button.js` and `Modal.js` import `theme.js`, editing `theme.js` will update
+  both components.
+- Finally, if you **edit a file** that's **imported by files outside of the
+  React tree**, Fast Refresh **will fall back to doing a full reload**. You
+  might have a file which renders a React component but also exports a value
+  that is imported by a **non-React component**. For example, maybe your
+  component also exports a constant, and a non-React utility file imports it. In
+  that case, consider migrating the constant to a separate file and importing it
+  into both files. This will re-enable Fast Refresh to work. Other cases can
+  usually be solved in a similar way.
+<!-- textlint-enable ja-technical-writing/max-comma -->
+
+## Error Resilience
+
+### Syntax Errors
+
+If you make a syntax error during development, you can fix it and save the file
+again. The error will disappear automatically, so you won't need to reload the
+app. **You will not lose component state**.
+
+### Runtime Errors
+
+If you make a mistake that leads to a runtime error inside your component,
+you'll be greeted with a contextual overlay. Fixing the error will automatically
+dismiss the overlay, without reloading the app.
+
+Component state will be retained if the error did not occur during rendering. If
+the error did occur during rendering, React will remount your application using
+the updated code.
+
+If you have [error boundaries](https://reactjs.org/docs/error-boundaries.html)
+in your app (which is a good idea for graceful failures in production), they
+will retry rendering on the next edit after a rendering error. This means having
+an error boundary can prevent you from always getting reset to the root app
+state. However, keep in mind that error boundaries shouldn't be _too_ granular.
+They are used by React in production, and should always be designed
+intentionally.
+
+## Limitations
+
+Fast Refresh tries to preserve local React state in the component you're
+editing, but only if it's safe to do so. Here's a few reasons why you might see
+local state being reset on every edit to a file:
+
+- Local state is not preserved for class components (only function components
+  and Hooks preserve state).
+- The file you're editing might have _other_ exports in addition to a React
+  component.
+- Sometimes, a file would export the result of calling higher-order component
+  like `higherOrderComponent(WrappedComponent)`. If the returned component is a
+  class, state will be reset.
+
+As more of your codebase moves to function components and Hooks, you can expect
+state to be preserved in more cases.
+
+## Tips
+
+- Fast Refresh preserves React local state in function components (and Hooks) by
+  default.
+- Sometimes you might want to _force_ the state to be reset, and a component to
+  be remounted. For example, this can be handy if you're tweaking an animation
+  that only happens on mount. To do this, you can add `// @refresh reset`
+  anywhere in the file you're editing. This directive is local to the file, and
+  instructs Fast Refresh to remount components defined in that file on every
+  edit.
+- You can put `console.log` or `debugger;` into the components you edit during
+  development.
+
+## Fast Refresh and Hooks
+
+When possible, Fast Refresh attempts to preserve the state of your component
+between edits. In particular, `useState` and `useRef` preserve their previous
+values as long as you don't change their arguments or the order of the Hook
+calls.
+
+Hooks with dependencies—such as `useEffect`, `useMemo`, and `useCallback`—will
+_always_ update during Fast Refresh. Their list of dependencies will be ignored
+while Fast Refresh is happening.
+
+<!-- textlint-disable ja-technical-writing/no-exclamation-question-mark -->
+For example, when you edit `useMemo(() => x * 2, [x])` to
+`useMemo(() => x * 10, [x])`, it will re-run even though `x` (the dependency)
+has not changed. If React didn't do that, your edit wouldn't reflect on the
+screen!
+<!-- textlint-enable ja-technical-writing/no-exclamation-question-mark -->
+
+Sometimes, this can lead to unexpected results. For example, even a `useEffect`
+with an empty array of dependencies would still re-run once during Fast Refresh.
+
+However, writing code resilient to occasional re-running of `useEffect` is a good practice even
+without Fast Refresh. It will make it easier for you to introduce new dependencies to it later on
+and it's enforced by [React Strict Mode](/docs/api-reference/next.config.js/react-strict-mode.md),
+which we highly recommend enabling.

--- a/docs/migrating/from-gatsby.md
+++ b/docs/migrating/from-gatsby.md
@@ -1,0 +1,255 @@
+---
+description: Learn how to transition an existing Gatsby project to Next.js.
+---
+
+# Migrating from Gatsby
+
+This guide will help you understand how to transition from an existing Gatsby project to Next.js. Migrating to Next.js will allow you to:
+
+- Choose which [data fetching](/docs/basic-features/data-fetching.md) strategy you want on a per-page basis.
+- Use [Incremental Static Regeneration](/docs/basic-features/data-fetching.md#incremental-static-regeneration) to update _existing_ pages by re-rendering them in the background as traffic comes in.
+- Use [API Routes](/docs/api-routes/introduction.md).
+
+<!-- textlint-disable ja-technical-writing/no-exclamation-question-mark -->
+And more! Let’s walk through a series of steps to complete the migration.
+<!-- textlint-enable ja-technical-writing/no-exclamation-question-mark -->
+
+## Updating `package.json` and dependencies
+
+The first step towards migrating to Next.js is to update `package.json` and dependencies. You should:
+
+- Remove all Gatsby-related packages (but keep `react` and `react-dom`).
+- Install `next`.
+- Add Next.js related commands to `scripts`. One is `next dev`, which runs a development server at `localhost:3000`. You should also add `next build` and `next start` for creating and starting a production build.
+
+Here's an example `package.json` ([view diff](https://github.com/leerob/gatsby-to-nextjs/pull/1/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)):
+
+```json
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}
+```
+
+## Static Assets and Compiled Output
+
+Gatsby uses the `public` directory for the compiled output, whereas Next.js uses it for static assets. Here are the steps for migration ([view diff](https://github.com/leerob/gatsby-to-nextjs/pull/1/files#diff-a084b794bc0759e7a6b77810e01874f2)):
+
+- Remove `.cache/` and `public` from `.gitignore` and delete both directories.
+- Rename Gatsby’s `static` directory as `public`.
+- Add `.next` to `.gitignore`.
+
+## Creating Routes
+
+Both Gatsby and Next support a `pages` directory, which uses [file-system based routing](/docs/routing/introduction.md). Gatsby's directory is `src/pages`, which is also [supported by Next.js](/docs/advanced-features/src-directory.md).
+
+Gatsby creates dynamic routes using the `createPages` API inside of `gatsby-node.js`. With Next, we can use [Dynamic Routes](/docs/routing/dynamic-routes.md) inside of `pages` to achieve the same effect. Rather than having a `template` directory, you can use the React component inside your dynamic route file. For example:
+
+- **Gatsby:** `createPages` API inside `gatsby-node.js` for each blog post, then have a template file at `src/templates/blog-post.js`.
+- **Next:** Create `pages/blog/[slug].js` which contains the blog post template. The value of `slug` is accessible through a [query parameter](/docs/routing/dynamic-routes.md). For example, the route `/blog/first-post` would forward the query object `{ 'slug': 'first-post' }` to `pages/blog/[slug].js` ([learn more here](/docs/basic-features/data-fetching.md#getstaticpaths-static-generation)).
+
+## Styling
+
+With Gatsby, global CSS imports are included in `gatsby-browser.js`. With Next, you should create a [custom `_app.js`](/docs/advanced-features/custom-app.md) for global CSS. When migrating, you can copy over your CSS imports directly and update the relative file path, if necessary. Next.js has [built-in CSS support](/docs/basic-features/built-in-css-support.md).
+
+## Links
+
+The Gatsby `Link` and Next.js [`Link`](/docs/api-reference/next/link.md) component have a slightly different API. First, you will need to update any import statements referencing `Link` from Gatsby to:
+
+```js
+import Link from 'next/link'
+```
+
+Next, you can find and replace usages of `to="/route"` with `href="/route"`.
+
+## Data Fetching
+
+The largest difference between Gatsby and Next.js is how data fetching is implemented. Gatsby is opinionated with GraphQL being the default strategy for retrieving data across your application. With Next.js, you get to choose which strategy you want (GraphQL is one supported option).
+
+Gatsby uses the `graphql` tag to query data in the pages of your site. This may include local data, remote data, or information about your site configuration. Gatsby only allows the creation of static pages. With Next.js, you can choose on a [per-page basis](/docs/basic-features/pages.md) which [data fetching strategy](/docs/basic-features/data-fetching.md) you want. For example, `getServerSideProps` allows you to do server-side rendering. If you wanted to generate a static page, you'd export `getStaticProps` / `getStaticPaths` inside the page, rather than using `pageQuery`. For example:
+
+```js
+// src/pages/[slug].js
+
+// Install remark and remark-html
+import remark from 'remark'
+import html from 'remark-html'
+import { getPostBySlug, getAllPosts } from '../lib/blog'
+
+export async function getStaticProps({ params }) {
+  const post = getPostBySlug(params.slug)
+  const content = await remark()
+    .use(html)
+    .process(post.content || '')
+    .toString()
+
+  return {
+    props: {
+      ...post,
+      content,
+    },
+  }
+}
+
+export async function getStaticPaths() {
+  const posts = getAllPosts()
+
+  return {
+    paths: posts.map((post) => {
+      return {
+        params: {
+          slug: post.slug,
+        },
+      }
+    }),
+    fallback: false,
+  }
+}
+```
+
+You'll commonly see Gatsby plugins used for reading the file system (`gatsby-source-filesystem`), handling markdown files (`gatsby-transformer-remark`), and so on. For example, the popular starter blog example has [15 Gatsby specific packages](https://github.com/gatsbyjs/gatsby-starter-blog/blob/master/package.json). Next takes a different approach. It includes common features directly inside the framework, and gives the user full control over integrations with external packages. For example, rather than abstracting reading from the file system to a plugin, you can use the native Node.js `fs` package inside `getStaticProps` / `getStaticPaths` to read from the file system.
+
+```js
+// src/lib/blog.js
+
+// Install gray-matter and date-fns
+import matter from 'gray-matter'
+import { parseISO, format } from 'date-fns'
+import fs from 'fs'
+import { join } from 'path'
+
+// Add markdown files in `src/content/blog`
+const postsDirectory = join(process.cwd(), 'src', 'content', 'blog')
+
+export function getPostBySlug(slug) {
+  const realSlug = slug.replace(/\\.md$/, '')
+  const fullPath = join(postsDirectory, `${realSlug}.md`)
+  const fileContents = fs.readFileSync(fullPath, 'utf8')
+  const { data, content } = matter(fileContents)
+  const date = format(parseISO(data.date), 'MMMM dd, yyyy')
+
+  return { slug: realSlug, frontmatter: { ...data, date }, content }
+}
+
+export function getAllPosts() {
+  const slugs = fs.readdirSync(postsDirectory)
+  const posts = slugs.map((slug) => getPostBySlug(slug))
+
+  return posts
+}
+```
+
+## Site Configuration
+
+With Gatsby, your site's metadata (name, description, etc) is located inside `gatsby-config.js`. This is then exposed through the GraphQL API and consumed through a `pageQuery` or a static query inside a component.
+
+With Next.js, we recommend creating a config file similar to below. You can then import this file anywhere without having to use GraphQL to access your site's metadata.
+
+```js
+// src/config.js
+
+export default {
+  title: 'Starter Blog',
+  author: {
+    name: 'Lee Robinson',
+    summary: 'who loves Next.js.',
+  },
+  description: 'A starter blog converting Gatsby -> Next.',
+  social: {
+    twitter: 'leeerob',
+  },
+}
+```
+
+## Search Engine Optimization
+
+Most Gatsby examples use `react-helmet` to assist with adding `meta` tags for proper SEO. With Next.js, we use [`next/head`](/docs/api-reference/next/head.md) to add `meta` tags to your `<head />` element. For example, here's an SEO component with Gatsby:
+
+```js
+// src/components/seo.js
+
+import { Helmet } from 'react-helmet'
+
+export default function SEO({ description, title, siteTitle }) {
+  return (
+    <Helmet
+      title={title}
+      titleTemplate={siteTitle ? `%s | ${siteTitle}` : null}
+      meta={[
+        {
+          name: `description`,
+          content: description,
+        },
+        {
+          property: `og:title`,
+          content: title,
+        },
+        {
+          property: `og:description`,
+          content: description,
+        },
+        {
+          property: `og:type`,
+          content: `website`,
+        },
+        {
+          name: `twitter:card`,
+          content: `summary`,
+        },
+        {
+          name: `twitter:creator`,
+          content: twitter,
+        },
+        {
+          name: `twitter:title`,
+          content: title,
+        },
+        {
+          name: `twitter:description`,
+          content: description,
+        },
+      ]}
+    />
+  )
+}
+```
+
+And here's the same example using Next.js, including reading from a site config file.
+
+```js
+// src/components/seo.js
+
+import Head from 'next/head'
+import config from '../config'
+
+export default function SEO({ description, title }) {
+  const siteTitle = config.title
+
+  return (
+    <Head>
+      <title>{`${title} | ${siteTitle}`}</title>
+      <meta name="description" content={description} />
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:site_name" content={siteTitle} />
+      <meta property="twitter:card" content="summary" />
+      <meta property="twitter:creator" content={config.social.twitter} />
+      <meta property="twitter:title" content={title} />
+      <meta property="twitter:description" content={description} />
+    </Head>
+  )
+}
+```
+
+## Learn more
+
+Take a look at [this pull request](https://github.com/leerob/gatsby-to-nextjs/pull/1) for more details on how an app can be migrated from Gatsby to Next.js. If you have questions or if this guide didn't work for you, feel free to reach out to our community on [GitHub Discussions](https://github.com/vercel/next.js/discussions).


### PR DESCRIPTION
- 最新(2020-10-19時点)の [vercel/next.js](https://github.com/vercel/next.js) ドキュメントにあり本リポジトリにないドキュメントファイルを追加

```
docs/migrating/from-gatsby.md
docs/basic-features/fast-refresh.md
docs/api-reference/next.config.js/trailing-slash.md
docs/api-reference/next.config.js/rewrites.md
docs/api-reference/next.config.js/redirects.md
docs/api-reference/next.config.js/react-strict-mode.md
docs/api-reference/next.config.js/headers.md
docs/api-reference/next.config.js/basepath.md
docs/api-reference/create-next-app.md
docs/advanced-features/debugging.md
docs/advanced-features/codemods.md
```