### PR TITLE
docs: fix link to edit page

### DIFF
--- a/components/docs/docs-page.js
+++ b/components/docs/docs-page.js
@@ -2,7 +2,7 @@ import { memo, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { getSlug, removeFromLast, addTagToSlug } from '../../lib/docs/utils';
-import { GITHUB_URL, REPO_NAME } from '../../lib/github/constants';
+import { GITHUB_URL, ORGANIZATION_NAME, REPOSITORY_NAME, DEFAULT_BRANCH } from '../../lib/github/constants';
 import addLinkListener from '../../lib/add-link-listener';
 import Notification from './notification';
 import FooterFeedback from '../footer-feedback';
@@ -19,7 +19,7 @@ function DocsPage({ route, html, prevRoute, nextRoute }) {
   const { query } = useRouter();
   const { tag, slug } = getSlug(query);
   const href = '/docs/[...slug]';
-  const editUrl = `${GITHUB_URL}/${REPO_NAME}/edit/canary${route.path}`;
+  const editUrl = `${GITHUB_URL}/${ORGANIZATION_NAME}/${REPOSITORY_NAME}/edit/${DEFAULT_BRANCH}${route.path}`;
 
   useEffect(() => {
     const listeners = [];

--- a/lib/docs/rehype-docs.js
+++ b/lib/docs/rehype-docs.js
@@ -2,7 +2,7 @@ import { resolve } from 'url';
 import visit from 'unist-util-visit';
 import toString from 'mdast-util-to-string';
 import GithubSlugger from 'github-slugger';
-import { GITHUB_URL, REPO_NAME } from '../github/constants';
+import { GITHUB_URL, ORGANIZATION_NAME, REPOSITORY_NAME, DEFAULT_BRANCH } from '../github/constants';
 import permalinkIcon from './permalink-icon-ast';
 
 const ABSOLUTE_URL = /^https?:\/\/|^\/\//i;
@@ -51,7 +51,7 @@ export default function rehypeDocs({ filePath, tag }) {
   const slugger = new GithubSlugger();
   const anchorSlugger = new GithubSlugger();
   // Don't use the custom tag here, relative URLs to repo files should always go to canary
-  const blobUrl = `${GITHUB_URL}/${REPO_NAME}/blob/canary`;
+  const blobUrl = `${GITHUB_URL}/${ORGANIZATION_NAME}/${REPOSITORY_NAME}/${DEFAULT_BRANCH}/blob/canary`;
 
   function visitAnchor(node) {
     const props = node.properties;

--- a/lib/github/api.js
+++ b/lib/github/api.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import fetch from '../fetch';
 import { readFile, writeFile } from '../fs-utils';
-import { GITHUB_API_URL, REPO_NAME } from './constants';
+import { GITHUB_API_URL, ORGANIZATION_NAME, REPOSITORY_NAME, DEFAULT_BRANCH } from './constants';
 
 const USE_CACHE = process.env.USE_CACHE === 'true';
 const TAG_CACHE_PATH = path.resolve('.github-latest-tag');
@@ -18,7 +18,9 @@ export async function getLatestTag() {
   }
 
   if (!cachedTag) {
-    const res = await fetch(`${GITHUB_API_URL}/repos/${REPO_NAME}/releases/latest`);
+    const res = await fetch(
+      `${GITHUB_API_URL}/repos/${ORGANIZATION_NAME}/${REPOSITORY_NAME}/${DEFAULT_BRANCH}/releases/latest`
+    );
 
     if (res.ok) {
       const data = await res.json();

--- a/lib/github/constants.js
+++ b/lib/github/constants.js
@@ -4,5 +4,8 @@ export const GITHUB_API_URL = 'https://api.github.com';
 
 export const RAW_GITHUB_URL = 'https://raw.githubusercontent.com';
 
-// ! 翻訳なのでバージョニング等は考えずに, 参照するブランチは master のみとしました
-export const REPO_NAME = 'Nextjs-ja-translation/Nextjs-ja-translation-docs/master';
+export const ORGANIZATION_NAME = 'Nextjs-ja-translation';
+
+export const REPOSITORY_NAME = 'Nextjs-ja-translation-docs';
+
+export const DEFAULT_BRANCH = 'master';

--- a/lib/github/raw.js
+++ b/lib/github/raw.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import pathMod from 'path';
 import fetch from '../fetch';
-import { RAW_GITHUB_URL, REPO_NAME } from './constants';
+import { RAW_GITHUB_URL, ORGANIZATION_NAME, REPOSITORY_NAME, DEFAULT_BRANCH } from './constants';
 
 function getErrorText(res) {
   try {
@@ -29,7 +29,7 @@ export async function getRawFileFromGitHub(path) {
 }
 
 export function getRawFileFromRepo(path) {
-  return getRawFileFromGitHub(`/${REPO_NAME}/${path}`);
+  return getRawFileFromGitHub(`/${ORGANIZATION_NAME}/${REPOSITORY_NAME}/${DEFAULT_BRANCH}/${path}`);
 }
 
 export async function getRawFileFromLocalProject(path) {


### PR DESCRIPTION
各ページの`Edit this page on GitHub`のリンクが壊れてしまっているので、その修正です。

また、その作業中に定数`REPO_NAME`の名前と内容が一致しておらず（リポジトリ名だけでなくオーガニゼーション名やブランチ名を含んでしまっている）、また他のバグを誘発してしまいそうだったので、定数の変更も行っています。