### PR TITLE
Chore change document link position

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -45,22 +45,24 @@ function Navbar() {
         </div>
 
         <div className="links">
-          <Link href="/">
-            <a className="logo">
-              <NextLogo />
-            </a>
-          </Link>
+          <div className="wrapper">
+            <Link href="/">
+              <a className="logo">
+                <NextLogo />
+              </a>
+            </Link>
 
-          <Link href="/docs/[...slug]" as="/docs/getting-started">
-            <a
-              className={cn('mute', {
-                selected: route.startsWith('/docs')
-              })}
-              title="Documentation"
-            >
-              Docs
-            </a>
-          </Link>
+            <Link href="/docs/[...slug]" as="/docs/getting-started">
+              <a
+                className={cn('link mute', {
+                  selected: route.startsWith('/docs')
+                })}
+                title="Documentation"
+              >
+                Docs
+              </a>
+            </Link>
+          </div>
 
           <a
             href="https://github.com/vercel/next.js"
@@ -89,6 +91,15 @@ function Navbar() {
           align-items: center;
           justify-content: space-between;
           z-index: 1;
+        }
+
+        .wrapper {
+          display: flex;
+          align-items: center;
+        }
+
+        .link {
+          margin-left: 2rem;
         }
 
         .links a {
@@ -152,6 +163,10 @@ function Navbar() {
 
           nav .links a {
             font-size: 14px;
+          }
+
+          .link {
+            margin-left: 0;
           }
 
           .mobile-top {


### PR DESCRIPTION
ドキュメントのリンク位置が気になったので修正しました。真ん中から左寄せに変更しています。

PC

![Screenshot from 2022-02-12 10-17-38](https://user-images.githubusercontent.com/39504660/153690463-a2d46b0e-7324-4903-9255-af9b46e4cffd.png)

モバイル

![Screenshot from 2022-02-12 10-18-04](https://user-images.githubusercontent.com/39504660/153690483-8e7afac2-205e-4d41-9a54-f7b01dfb3fc6.png)
