### PR TITLE
fix: 外部リンクでnext/linkを使って出てしまっているエラーを修正

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -70,9 +70,13 @@ export default withPure(() => (
               </Link>
             </p>
             <p>
-              <Link href="https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs#contributors-">
-                <a>コントリビューター</a>
-              </Link>
+              <a
+                href="https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs#contributors-"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                コントリビューター
+              </a>
             </p>
           </div>
           <div>


### PR DESCRIPTION
# 概要
外部リンクでnext/linkを使って出てしまっているためにエラーが出ている。

https://qiita.com/srkw___/items/b9fef78c2fb29069b203#nextlink%E3%81%AE%E5%A4%96%E9%83%A8%E3%83%AA%E3%83%B3%E3%82%AF%E3%81%A8%E3%81%97%E3%81%A6%E3%81%AE%E4%BD%BF%E7%94%A8%E6%B3%95%E3%81%AE%E5%BB%83%E6%AD%A2

![image](https://user-images.githubusercontent.com/44350989/153836755-867a97d2-9dc4-46a3-8149-51e822d6ce3c.png)

# 再現方法
READMEの通りに

```
$ git clone https://github.com/your/Nextjs-ja-translation-docs
$ cd Nextjs-ja-translation-docs
$ yarn install
$ yarn dev
```
してlocalhost:3000を開くと出る

# 修正比較
## 修正前
![image](https://user-images.githubusercontent.com/44350989/153837448-88bfb4e1-124a-401e-b175-791e9260a7f5.png)

## 修正後
![image](https://user-images.githubusercontent.com/44350989/153837527-f6fd6e60-a4ce-4d24-8ef4-c27e7746ea70.png)

デザイン崩れはなし
