### PR TITLE
Chore: api-reference/next.config.js/environment-variables の追従

### DIFF
--- a/docs/api-reference/next.config.js/environment-variables.md
+++ b/docs/api-reference/next.config.js/environment-variables.md
@@ -4,13 +4,12 @@ description: ビルド時に、Next.jsアプリケーションに環境変数を
 
 # 環境変数
 
-> Next.js 9.4のリリース以降、[環境変数の追加](/docs/basic-features/environment-variables.md)がより直感的で、自然に行えるようになりました。試してみてください！
+> [Next.js 9.4](https://nextjs.org/blog/next-9-4)のリリース以降、[環境変数の追加](/docs/basic-features/environment-variables.md)がより直感的で、自然に行えるようになりました。試してみてください！
 
 <details>
   <summary><b>例</b></summary>
   <ul>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-env-from-next-config-js">envのみ</a></li>
-    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-now-env">Nowとenv</a></li>
   </ul>
 </details>
 


### PR DESCRIPTION
https://github.com/vercel/next.js/blob/canary/docs/api-reference/next.config.js/environment-variables.md