### PR TITLE
Chore: api-reference/next.config.js/ignoring-eslint.md の更新

### DIFF
--- a/docs/api-reference/next.config.js/ignoring-eslint.md
+++ b/docs/api-reference/next.config.js/ignoring-eslint.md
@@ -1,0 +1,37 @@
+---
+description: Next.js reports ESLint errors and warnings during builds by default. Learn how to opt-out of this behavior here.
+---
+
+# Ignoring ESLint
+
+When ESLint is detected in your project, Next.js fails your **production build** (`next build`) when errors are present.
+
+If you'd like Next.js to produce production code even when your application has ESLint errors, you can disable the built-in linting step completely. This is not recommended unless you already have ESLint configured to run in a separate part of your workflow (for example, in CI or a pre-commit hook).
+
+Open `next.config.js` and enable the `ignoreDuringBuilds` option in the `eslint` config:
+
+```js
+module.exports = {
+  eslint: {
+    // Warning: This allows production builds to successfully complete even if
+    // your project has ESLint errors.
+    ignoreDuringBuilds: true,
+  },
+}
+```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/eslint.md">
+    <b>ESLint:</b>
+    <small>Get started with ESLint in Next.js.</small>
+  </a>
+</div>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -353,6 +353,10 @@
               "path": "/docs/api-reference/next.config.js/configuring-onDemandEntries.md"
             },
             {
+              "title": "Ignoring ESLint",
+              "path": "/docs/api-reference/next.config.js/ignoring-eslint.md"
+            },
+            {
               "title": "TypeScriptのエラーを無視する",
               "path": "/docs/api-reference/next.config.js/ignoring-typescript-errors.md"
             },


### PR DESCRIPTION
#3 に追記済み

https://github.com/vercel/next.js/blob/canary/docs/api-reference/next.config.js/ignoring-eslint.md?plain=1