### PR TITLE
Chore: api-reference/next.config.js/introduction.md の更新

### DIFF
--- a/docs/api-reference/next.config.js/introduction.md
+++ b/docs/api-reference/next.config.js/introduction.md
@@ -4,7 +4,7 @@ description: アプリケーションを処理するために、Next.jsが使用
 
 # next.config.js
 
-Next.js の高度な動作をカスタマイズするには、プロジェクトディレクトリのルートに `next.config.js` を作成します(`package.json` と同じディレクトリ)。
+Next.js の高度な動作をカスタマイズするには、プロジェクトディレクトリのルートに `next.config.js` か `next.config.mjs` を作成します(`package.json` と同じディレクトリ)。
 
 `next.config.js` は通常の Node.js モジュールであり JSON ファイルではありません。
 Next.js サーバーとビルドフェーズで使用され、ブラウザのビルドには含まれません。
@@ -12,23 +12,57 @@ Next.js サーバーとビルドフェーズで使用され、ブラウザのビ
 `next.config.js` の例を見てみましょう:
 
 ```js
+/**
+ * @type {import('next').NextConfig}
+ */
 module.exports = {
   /* ここにオプション設定を書きます */
 };
+```
+
+もし [ECMAScript modules](https://nodejs.org/api/esm.html) が必要であれば、 `next.config.mjs` を使うこともできます:
+
+```js
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  /* ここにオプション設定を書きます */
+}
+
+export default nextConfig
 ```
 
 関数も利用できます:
 
 ```js
 module.exports = (phase, { defaultConfig }) => {
-  return {
+  /**
+   * @type {import('next').NextConfig}
+   */
+  const nextConfig = {
     /* ここにオプション設定を書きます */
-  };
+  }
+  return nextConfig
 };
 ```
 
+Next.js 12.1.0 からは非同期関数を使うこともできます:
+
+```js
+module.exports = async (phase, { defaultConfig }) => {
+  /**
+   * @type {import('next').NextConfig}
+   */
+  const nextConfig = {
+    /* ここにオプション設定を書きます */
+  }
+  return nextConfig
+}
+```
+
 `phase` は設定がロードされている現在のフェーズです。
-利用可能なフェーズは[こちら](https://github.com/vercel/next.js/blob/canary/packages/next/next-server/lib/constants.ts#L1-L4)を参照ください。
+利用可能なフェーズは[こちら](https://github.com/vercel/next.js/blob/canary/packages/next/shared/lib/constants.ts#L1-L5)を参照ください。
 フェーズは `next/constants` からインポート出来ます:
 
 ```js
@@ -42,13 +76,13 @@ module.exports = (phase, { defaultConfig }) => {
   }
 
   return {
-    /* 開発フェーズを除く全てのフェーズで有効なオプションを設定 */
+    /* 開発フェーズを除く全てのフェーズで有効なオプションを設定 */
   };
 };
 ```
 
 コメントされている行は `next.config.js` で許可された設定が挿入可能な箇所です。
-定義は[こちら](https://github.com/vercel/next.js/blob/canary/packages/next/next-server/server/config.ts#L12-L63)をご覧ください。
+定義は[こちら](https://github.com/vercel/next.js/blob/canary/packages/next/server/config-shared.ts#L68)をご覧ください。
 
 ただし、いずれの設定も必要でなく、全ての設定を完全に理解する必要はありません。
 有効化または修正する必要がある設定のみ調べて変更するようにお勧めします。


### PR DESCRIPTION
https://github.com/vercel/next.js/blob/canary/docs/api-reference/next.config.js/introduction.md