### PR TITLE
Chore: api-reference/next/link の更新

### DIFF
--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -8,6 +8,7 @@ description: 組み込みの Link コンポーネントを使用して、ルー�
   <summary><b>例</b></summary>
   <ul>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/hello-world">Hello World</a></li>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/active-class-name">Active className on Link</a></li>
   </ul>
 </details>
 
@@ -15,10 +16,16 @@ description: 組み込みの Link コンポーネントを使用して、ルー�
 
 ルート間のクライアント側のトランジションは、`next/link` でエクスポートされた `Link` コンポーネントを介して有効にできます。
 
-`/` と `/about` をリンクした例:
+例として、以下のファイルを含む `pages` ディレクトリを考えてみましょう:
+
+- `pages/index.js`
+- `pages/about.js`
+- `pages/blog/[slug].js`
+
+以下のようにして、それぞれのページに対してリンクを設定できます:
 
 ```jsx
-import Link from 'next/link';
+import Link from 'next/link'
 
 function Home() {
   return (
@@ -33,81 +40,89 @@ function Home() {
           <a>About Us</a>
         </Link>
       </li>
+      <li>
+        <Link href="/blog/hello-world">
+          <a>Blog Post</a>
+        </Link>
+      </li>
     </ul>
-  );
+  )
 }
 
-export default Home;
+export default Home
 ```
 
-`Link` は以下のような props を受け入れる:
+`Link` は以下の props を受け入れます:
 
-- `href` - `pages` ディレクトリ内のパス。これは唯一必須のプロパティです。
-- `as` - ブラウザの URL バーに表示されるパス。動的ルーティングに使用されます。
+- `href` - 遷移したい先のパスまたは URL です。これは唯一必須のプロパティです。
+- `as` - ブラウザの URL バーに表示される、パスのオプショナルなデコレーターです。Next.js 9.5.3 以前は動的ルーティングに使用されていました。以前のバージョンでどのように動作していたかを知りたい場合は[過去のドキュメント](https://nextjs.org/docs/tag/v9.5.2/api-reference/next/link#dynamic-routes)をご確認ください。備考: このパスが `href` で与えられるパスと異なる場合は、以前の `href`/`as` の挙動になります。詳細は[過去のドキュメント](https://nextjs.org/docs/tag/v9.5.2/api-reference/next/link#dynamic-routes)に記載があります。
 - [`passHref`](#子が-a-タグをラップするカスタムコンポーネントの場合) - `Link` が子に `href` プロパティを強制送信します。デフォルトは `false` です。
-- `prefetch` - バックグラウンドでページをプリフェッチします。デフォルトは `true` です。ビューポート内にある `<Link />` はすべてプリロードされます (初期状態やスクロール中)。[静的生成](/docs/basic-features/data-fetching#getstaticprops-static-generation)を使用しているページでは、ページ遷移を高速化するためにデータと一緒に `JSON` ファイルがプリロードされます。
+- `prefetch` - バックグラウンドでページをプリフェッチします。デフォルトは `true` です。ビューポート内にある `<Link />` はすべてプリロードされます (初期状態やスクロール中)。`prefetch={false}` を渡すことでプリフェッチは無効になります。`prefetch` が `false` に設定されている場合でも、ホバー時にはプリフェッチが行われます。[静的生成](/docs/basic-features/data-fetching#getstaticprops-static-generation)を使用しているページでは、ページ遷移を高速化するためにデータと一緒に `JSON` ファイルがプリロードされます。プリフェッチは本番環境でのみ有効です。
 - [`replace`](#プッシュの代わりにURLを置換する) - スタックに新しい URL を追加する代わりに、現在の `history` の state を置き換えます。デフォルトは `false` です。
 - [`scroll`](#ページ上部へのスクロールを無効にする) - ナビゲーションの後にページの先頭にスクロールします。デフォルトは `true` です。
 - [`shallow`](/docs/routing/shallow-routing.md) - [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation)、 [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering)、 [`getInitialProps`](/docs/api-reference/data-fetching/getInitialProps.md) を再実行せずに現在のページのパスを更新します。デフォルトは `false` です。
+- `locale` - アクティブなロケールが自動的に先頭に追加されます。`locale` を設定することで異なるロケールを指定できます。`false` の場合は、デフォルトの動作が無効であるため `href` にロケールを含める必要があります。
 
-外部 URL や `/pages` を使ったルートナビゲーションを必要としないリンクは、`Link` で処理する必要はありません; このような場合には、代わりにアンカータグを使用してください。
+## ルーティングに動的なセグメントが含まれる場合
 
-## 動的ルーティング
+Next.js 9.5.3 以降では（古いバージョンについては[過去のドキュメント](https://nextjs.org/docs/tag/v9.5.2/api-reference/next/link#dynamic-routes)をご確認ください）、何もせずとも[動的ルーティング](/docs/routing/dynamic-routes.md)（[すべてのルートを受け取る](/docs/routing/dynamic-routes.md#catch-all-routes)場合を含めて）へのリンクを設定できます。しかし、[補間](/docs/routing/introduction.md#linking-to-dynamic-paths) や [URL オブジェクト](#with-url-object)を用いてリンクを生成することが非常に一般的で便利な状況も存在します。
 
-動的ルーティングへの `Link` は、`href` と `as` の props の組み合わせです。`pages/post/[pid].js` のページへのリンクは以下のようになります:
-
-```jsx
-<Link href="/post/[pid]" as="/post/abc">
-  <a>First Post</a>
-</Link>
-```
-
-`href` はページが使用するファイルシステムのパスであり、実行時に変更されるべきではありません。一方、 `as` は必要に応じてほとんどの場合動的に変化します。ここでは、リンクのリストを作成する方法の例を示します:
+たとえば、 `pages/blog/[slug].js` という動的ルーティングは以下のリンクにマッチします:
 
 ```jsx
-const pids = ['id1', 'id2', 'id3'];
-{
-  pids.map(pid => (
-    <Link href="/post/[pid]" as={`/post/${pid}`}>
-      <a>Post {pid}</a>
-    </Link>
-  ));
+import Link from 'next/link'
+
+function Posts({ posts }) {
+  return (
+    <ul>
+      {posts.map((post) => (
+        <li key={post.id}>
+          <Link href={`/blog/${encodeURIComponent(post.slug)}`}>
+            <a>{post.title}</a>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  )
 }
+
+export default Posts
 ```
 
 ## 子が `<a>` タグをラップするカスタムコンポーネントの場合
 
-`Link` の子が `<a>` タグをラップするカスタムコンポーネントの場合は、`Link` に `passHref` を追加する必要があります。これは [styled-components](https://styled-components.com/) のようなライブラリを使用している場合は必要です。これがないと、`<a>` タグには `href` 属性が付与されず、サイトの SEO に悪影響を及ぼす可能性があります。
+`Link` の子が `<a>` タグをラップするカスタムコンポーネントの場合は、`Link` に `passHref` を追加する必要があります。これは [styled-components](https://styled-components.com/) のようなライブラリを使用している場合は必要です。これがないと、`<a>` タグには `href` 属性が付与されず、サイトのアクセシビリティを損ない、SEO に悪影響を及ぼす可能性があります。[ESLint](/docs/basic-features/eslint.md#eslint-plugin) を使っている場合は、`passHref` の正しく使用するための `next/link-passhref` という組み込みのルールがあります。
 
 ```jsx
-import Link from 'next/link';
-import styled from 'styled-components';
+import Link from 'next/link'
+import styled from 'styled-components'
 
-// これは、<a>タグをラップするカスタムコンポーネントを作成します
+// これは、<a> タグをラップするカスタムコンポーネントを作成します
 const RedLink = styled.a`
   color: red;
-`;
+`
 
 function NavLink({ href, name }) {
-  // リンクにpassHrefを追加する必要があります
+  // リンクに passHref を追加する必要があります
   return (
     <Link href={href} passHref>
       <RedLink>{name}</RedLink>
     </Link>
-  );
+  )
 }
 
-export default NavLink;
+export default NavLink
 ```
 
-> **備考**: [emotion](https://emotion.sh/) の JSX pragma 機能(`@jsx jsx`)を使用している場合は、`<a>` タグを直接使用していても `passHref` を使用しなければなりません。
+- [emotion](https://emotion.sh/) の JSX pragma 機能(`@jsx jsx`)を使用している場合は、`<a>` タグを直接使用していても `passHref` を使用しなければなりません。
+- ページ遷移を正しくトリガーするために、コンポーネントは `onClick` 属性をサポートする必要があります。
 
 ## 子が関数コンポーネントの場合
 
-`Link` の子が関数コンポーネントの場合、`passHref` の使用に加えて、[`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref) でコンポーネントをラップする必要があります:
+`Link` の子が関数コンポーネントの場合、`passHref` の使用に加えて、[`React.forwardRef`](https://ja.reactjs.org/docs/react-api.html#reactforwardref) でコンポーネントをラップする必要があります:
 
 ```jsx
-import Link from 'next/link';
+import Link from 'next/link'
 
 // `onClick`, `href`, `ref` を適切に処理するためには
 // DOM 要素に渡す必要があります
@@ -116,43 +131,65 @@ const MyButton = React.forwardRef(({ onClick, href }, ref) => {
     <a href={href} onClick={onClick} ref={ref}>
       Click Me
     </a>
-  );
-});
+  )
+})
 
 function Home() {
   return (
     <Link href="/about" passHref>
       <MyButton />
     </Link>
-  );
+  )
 }
 
-export default Home;
+export default Home
 ```
 
-## URLオブジェクト
+## URL オブジェクト
 
 `Link` は URL オブジェクトを受け取ることもでき、それを自動的にフォーマットして URL 文字列を作成してくれます。その方法は以下の通りです:
 
 ```jsx
-import Link from 'next/link';
+import Link from 'next/link'
 
 function Home() {
   return (
-    <div>
-      <Link href={{ pathname: '/about', query: { name: 'test' } }}>
-        <a>About us</a>
-      </Link>
-    </div>
-  );
+    <ul>
+      <li>
+        <Link
+          href={{
+            pathname: '/about',
+            query: { name: 'test' },
+          }}
+        >
+          <a>About us</a>
+        </Link>
+      </li>
+      <li>
+        <Link
+          href={{
+            pathname: '/blog/[slug]',
+            query: { slug: 'my-post' },
+          }}
+        >
+          <a>Blog Post</a>
+        </Link>
+      </li>
+    </ul>
+  )
 }
 
-export default Home;
+export default Home
 ```
 
-上記の例では、`/about?name=test` へのリンクになります。[Node.jsのURLモジュールのドキュメント](https://nodejs.org/api/url.html#url_url_strings_and_url_objects)で定義されているすべてのプロパティを使用できます。
+上記の例には以下へのリンクが含まれています:
 
-## プッシュの代わりにURLを置換する
+- 事前に定められたルーティング: `/about?name=test`
+- [動的ルーティング](/docs/routing/dynamic-routes.md): `/blog/my-post`
+
+[Node.js の URL モジュールのドキュメント](https://nodejs.org/api/url.html#url_url_strings_and_url_objects)で定義されているすべてのプロパティを使用できます。
+
+## プッシュの代わりに URL を置換する
 
 `Link` コンポーネントのデフォルトの挙動は、新しい URL を `history` スタックに `push` することです。以下の例のように、`replace` prop を使って新しいエントリを追加しないようにできます:
 
@@ -161,18 +198,6 @@ export default Home;
   <a>About us</a>
 </Link>
 ```
-
-## `onClick` をサポートするコンポーネントを使う
-
-`Link` は `onClick` イベントをサポートする任意のコンポーネントをサポートしますが、`<a>` タグを指定しない場合は、以下の例を考えてみましょう:
-
-```jsx
-<Link href="/about">
-  <img src="/static/image.png" alt="image" />
-</Link>
-```
-
-`Link` の子は `<a>` の代わりに `<img>` となります。`Link` は `onClick` プロパティを `<img>` に送りますが、`href` プロパティは渡しません。
 
 ## ページ上部へのスクロールを無効にする
 

--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -65,7 +65,7 @@ export default Home
 
 ## ルーティングに動的なセグメントが含まれる場合
 
-Next.js 9.5.3 以降では（古いバージョンについては[過去のドキュメント](https://nextjs.org/docs/tag/v9.5.2/api-reference/next/link#dynamic-routes)をご確認ください）、何もせずとも[動的ルーティング](/docs/routing/dynamic-routes.md)（[すべてのルートを受け取る](/docs/routing/dynamic-routes.md#catch-all-routes)場合を含めて）へのリンクを設定できます。しかし、[補間](/docs/routing/introduction.md#linking-to-dynamic-paths) や [URL オブジェクト](#with-url-object)を用いてリンクを生成することが非常に一般的で便利な状況も存在します。
+Next.js 9.5.3 以降では（古いバージョンについては[過去のドキュメント](https://nextjs.org/docs/tag/v9.5.2/api-reference/next/link#dynamic-routes)をご確認ください）、何もせずとも[動的ルーティング](/docs/routing/dynamic-routes.md)（[すべてのルートを受け取る](/docs/routing/dynamic-routes.md#catch-all-routes)場合を含めて）へのリンクを設定できます。しかし、[文字列補間](/docs/routing/introduction.md#linking-to-dynamic-paths) や [URL オブジェクト](#with-url-object)を用いてリンクを生成することが非常に一般的で便利な状況も存在します。
 
 たとえば、 `pages/blog/[slug].js` という動的ルーティングは以下のリンクにマッチします:
 


### PR DESCRIPTION
https://github.com/vercel/next.js/blob/canary/docs/api-reference/next/link.md