### PR TITLE
api-routes/dynamic-api-routesの翻訳漏れ修正

### DIFF
--- a/docs/api-routes/dynamic-api-routes.md
+++ b/docs/api-routes/dynamic-api-routes.md
@@ -84,7 +84,7 @@ export default function handler(req, res) {
 
 例えば、`pages/api/post/[[...slug]].js` は `/api/post`、`/api/post/a`、`/api/post/a/b` などに一致します。
 
-`[...slug]`との主な違いは、パラメータを持たないルートもマッチすることです（上の例では `/api/post`）。
+`[...slug]` との主な違いは、パラメータを持たないルートもマッチすることです（上の例では `/api/post`）。
 
 `query` オブジェクトは次のようになります:
 

--- a/docs/api-routes/dynamic-api-routes.md
+++ b/docs/api-routes/dynamic-api-routes.md
@@ -84,6 +84,8 @@ export default function handler(req, res) {
 
 例えば、`pages/api/post/[[...slug]].js` は `/api/post`、`/api/post/a`、`/api/post/a/b` などに一致します。
 
+`[...slug]`との主な違いは、パラメータを持たないルートもマッチすることです（上の例では `/api/post`）。
+
 `query` オブジェクトは次のようになります:
 
 ```json


### PR DESCRIPTION
公式ドキュメントと見比べて日本語訳に翻訳漏れを見つけたので修正します。

https://nextjs.org/docs/api-routes/dynamic-api-routes

`docs/api-routes/dynamic-api-routes` の `Optional catch all API routes` の中の以下の文が日本語訳から抜けていたので追加しました。

```
The main difference between catch all and optional catch all routes is that with optional, the route without the parameter is also matched (/api/post in the example above).
```