### PR TITLE
Fix outdated instructions in from-gatsby.md

### DIFF
--- a/docs/migrating/from-gatsby.md
+++ b/docs/migrating/from-gatsby.md
@@ -81,14 +81,12 @@ import Link from 'next/link'
 
 export default function Home() {
   return (
-    <Link href="/blog">
-      <a>blog</a>
-    </Link>
+    <Link href="/blog">blog</Link>
   )
 }
 ```
 
-Update any import statements, switch `to` to `href`, and add an `<a>` tag as a child of the element.
+Update any import statements, switch `to` to `href`. For versions prior to Next.js version 13, add an `<a>` tag as a child of the Link element.
 
 ## Data Fetching
 


### PR DESCRIPTION
The original instructions when converting from gatsby to next had users wrap the inner HTML inside the "Link" in an "a" tag, this is incorrect as of version 13+ and throws an error. I just refactored my project as per the instructions and am now going through to revert it. Tweaked wording and example for the correct and updated process.

Also, if you're hiring I'm currently looking for a job :D
Cheers